### PR TITLE
fix: publica CLI no npm apenas via tag de versão

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,9 +2,9 @@ name: NPM Publish
 
 on:
   push:
-    branches: [main]
-    paths:
-      - 'package.json'
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -21,6 +21,17 @@ jobs:
         run: |
           bun install --frozen-lockfile
           cd libs/koala-nest && bun install --frozen-lockfile
+
+      - name: Validate release tag
+        if: github.event_name == 'push'
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VERSION=$(node -p "require('./package.json').version")
+
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "Tag v${TAG} não corresponde à versão do package.json (${VERSION})." >&2
+            exit 1
+          fi
 
       - name: Check if version is already published
         id: check_version


### PR DESCRIPTION
## Summary
- Remove o trigger de publish em push para `main` quando `package.json` muda
- Publica `@koalarx/nest` somente com tag `v*` (fluxo `npm version`) ou disparo manual (`workflow_dispatch`)
- Valida que a tag corresponde à versão do `package.json` antes de publicar

## Motivação
Merges em `main` (docs, refactors, etc.) não devem publicar a CLI no npm automaticamente. O release fica explícito via tag de versão.

## Test plan
- [ ] CI (PR Tests)
- [ ] Após merge, confirmar que push em `main` sem tag não dispara NPM Publish
- [ ] Publicação futura: `npm run prepare:release` → tag `v4.0.0` → workflow NPM Publish


Made with [Cursor](https://cursor.com)