### PR TITLE
4.0.1

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,9 +2,9 @@ name: NPM Publish
 
 on:
   push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+    branches: [main]
+    paths:
+      - 'package.json'
 
 jobs:
   publish:
@@ -21,17 +21,6 @@ jobs:
         run: |
           bun install --frozen-lockfile
           cd libs/koala-nest && bun install --frozen-lockfile
-
-      - name: Validate release tag
-        if: github.event_name == 'push'
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          VERSION=$(node -p "require('./package.json').version")
-
-          if [ "$TAG" != "$VERSION" ]; then
-            echo "Tag v${TAG} não corresponde à versão do package.json (${VERSION})." >&2
-            exit 1
-          fi
 
       - name: Check if version is already published
         id: check_version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/nest",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "CLI para criar APIs NestJS com arquitetura DDD — copia módulos prontos para o seu repositório.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI release semantics changed so any merged package.json version bump on main can trigger a publish; safeguards are limited to the existing npm duplicate-version skip, not tag alignment.
> 
> **Overview**
> Bumps **`@koalarx/nest`** from **4.0.0** to **4.0.1** and adjusts how releases reach npm.
> 
> The **NPM Publish** workflow no longer runs on version tags or **`workflow_dispatch`**. It now runs on pushes to **`main`** that touch **`package.json`**. The step that enforced tag **`v*`** matching **`package.json`** version was removed; publishing still depends on the existing **“already published?”** npm registry check before build/publish.
> 
> Also fixes **`package.json`** ending with a proper newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12cbb6dae2d56dc59c4d749aa96e1b3d111abaf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->