### PR TITLE
feat: habilita indexação da documentação no Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Facilitador para criar APIs NestJS com arquitetura DDD, focado em manutenção, 
 
 Em vez de depender de uma biblioteca opaca, a CLI **copia módulos prontos para dentro do projeto** — abordagem semelhante ao [shadcn/ui](https://ui.shadcn.com). Você recebe código que pode ler, adaptar e manter sem amarras futuras.
 
+**Documentação:** [nest.koalarx.com](https://nest.koalarx.com/) (PT e EN)
+
 ## O que está disponível hoje
 
 | Recurso | Status |
@@ -14,8 +16,8 @@ Em vez de depender de uma biblioteca opaca, a CLI **copia módulos prontos para 
 | Template **Exemplo de CRUD** (Person) | Disponível |
 | Autenticação (JWT, OAuth2) | Disponível na CLI |
 | API Key | Em breve |
-| Cache, health check, jobs internos | Disponível no template (exemplos Person) |
-| Comando `add` (módulos avulsos) | Em breve |
+| Cache, health check, jobs internos | Disponível via `new` e `add` |
+| Comando `add` (funcionalidades avulsas) | Disponível |
 
 ## Instalação e uso
 
@@ -57,11 +59,14 @@ npx @koalarx/nest@latest new
 | Comando | Descrição |
 | --- | --- |
 | `kl-nest new` | Cria um novo projeto (fluxo interativo) |
+| `kl-nest add` | Adiciona funcionalidades a um projeto existente |
 | `kl-nest version` | Exibe a versão da CLI |
 | `kl-nest help` | Lista comandos disponíveis |
 
 ```bash
 kl-nest new
+kl-nest add cache
+kl-nest add auth jwt health
 kl-nest version
 kl-nest --help
 
@@ -75,7 +80,22 @@ O comando `new` pergunta:
 - nome do projeto;
 - gerenciador de pacotes (`bun`, `npm` ou `pnpm` — Bun recomendado);
 - template (**Padrão** ou **Exemplo de CRUD**);
-- estratégia de autenticação (**JWT**, **OAuth2** ou nenhuma) e funcionalidades extras (opções futuras aparecem desabilitadas).
+- estratégia de autenticação (**JWT**, **OAuth2** ou nenhuma) e funcionalidades extras (cache, health, cron, eventos); **API Key** ainda aparece desabilitada no prompt;
+
+O comando `add` instala funcionalidades em um projeto Koala Nest já existente (detecta o que já está presente e pula duplicatas):
+
+- `auth jwt` / `auth oauth2` — autenticação
+- `cache` — cache Redis (com exemplos no template CRUD)
+- `health` — endpoint `GET /health`
+- `cron` — jobs com expressão cron
+- `events` — jobs reativos a eventos
+
+```bash
+cd meu-projeto
+kl-nest add cache
+kl-nest add auth jwt health --verbose
+kl-nest add cron events
+```
 
 ### Templates
 
@@ -115,7 +135,7 @@ Crie um `.env` na raiz do projeto gerado:
 ```env
 PORT=3000
 NODE_ENV=develop
-DATABASE_URL=postgres://user:password@localhost:5432/my_api
+DATABASE_URL=postgresql://user:password@localhost:5432/my_api
 ```
 
 ### Scripts úteis no projeto gerado
@@ -127,11 +147,14 @@ bun run migration:run      # aplica migrations pendentes
 bun run migration:revert   # reverte a última migration
 ```
 
-## Documentação para agentes de IA
+## Documentação
 
-Índice de documentação otimizado para LLMs:
+Site completo: **[nest.koalarx.com](https://nest.koalarx.com/)** — guias de instalação, arquitetura DDD, autenticação, cache, jobs e fluxo CRUD (português e inglês).
 
-https://nest.koalarx.com/llm.txt
+### Índices para agentes de IA
+
+- PT: https://nest.koalarx.com/llms.txt (alias: `/llm.txt`)
+- EN: https://nest.koalarx.com/llms-en.txt (alias: `/llm-en.txt`)
 
 ## Repositório (desenvolvimento)
 
@@ -151,8 +174,9 @@ O script `bun kl-nest` no `package.json` compila o projeto e executa a CLI a par
 koala-nest/
 ├── libs/
 │   ├── cli/          # código-fonte da CLI (kl-nest)
+│   ├── doc/          # markdown da documentação + site Angular
 │   └── koala-nest/   # templates copiados para projetos gerados
-├── scripts/          # build da CLI e dos templates
+├── scripts/          # build da CLI, docs e templates
 └── dist/             # saída do build (cli + koala-nest + package.json)
 ```
 
@@ -162,5 +186,6 @@ koala-nest/
 bun run build              # build completo (CLI + templates + dist/package.json)
 bun run build:cli          # apenas a CLI
 bun run build:koala-nest   # apenas os templates
-bun test                   # testes em libs/koala-nest
+bun run build:docs         # site de documentação
+bun test                   # testes do monorepo (CLI, lib, docs)
 ```

--- a/libs/doc/markdown/en/getting-started/installation-guide.md
+++ b/libs/doc/markdown/en/getting-started/installation-guide.md
@@ -151,7 +151,7 @@ pnpm run migration:run
 pnpm run migration:revert
 ```
 
-> **Important:** with the **CRUD Example** template, run `migration:run` before starting the API. The **Default** template has no initial migrations. Tests use Bun's native runner (`bun test` / `bun run test:e2e`).
+> **Important:** with the **CRUD Example** template, run `migration:run` before starting the API. The **Default** template has no initial migrations. Tests: **Bun** uses `bun test`; **npm/pnpm** use **Vitest** (`npm run test`). Generated projects do not include a `test:e2e` script by default.
 
 ## Local CLI development
 

--- a/libs/doc/markdown/en/host/openapi-scalar.md
+++ b/libs/doc/markdown/en/host/openapi-scalar.md
@@ -194,10 +194,11 @@ When authentication is installed, `define-documentation.ts` applies global `.add
 
 ### Documentation endpoint
 
-Change `docEndpoint` to modify the URL:
+The template uses `/doc` by default (`DOC_ENDPOINT` in `define-documentation.ts`). To change the URL:
 
 ```typescript
-const docEndpoint = '/api-docs';
+const docEndpoint = '/doc'; // template default
+// const docEndpoint = '/api-docs'; // example alternate URL
 ```
 
 Register the same value in `SwaggerModule.setup` and in `app.use`.

--- a/libs/doc/markdown/pt/host/openapi-scalar.md
+++ b/libs/doc/markdown/pt/host/openapi-scalar.md
@@ -194,10 +194,11 @@ Com autenticação instalada, `define-documentation.ts` aplica `.addBearerAuth()
 
 ### Endpoint da documentação
 
-Altere `docEndpoint` para mudar a URL:
+O template usa `/doc` por padrão (`DOC_ENDPOINT` em `define-documentation.ts`). Para mudar a URL:
 
 ```typescript
-const docEndpoint = '/api-docs';
+const docEndpoint = '/doc'; // padrão do template
+// const docEndpoint = '/api-docs'; // exemplo de URL alternativa
 ```
 
 Registre o mesmo valor em `SwaggerModule.setup` e em `app.use`.

--- a/libs/doc/markdown/pt/inicio/guia-de-instalacao.md
+++ b/libs/doc/markdown/pt/inicio/guia-de-instalacao.md
@@ -151,7 +151,7 @@ pnpm run migration:run
 pnpm run migration:revert
 ```
 
-> **Importante:** no template **Exemplo de CRUD**, execute `migration:run` antes de iniciar a API. No template **Padrão** não há migrations iniciais. Os testes usam o runner nativo do Bun (`bun test` / `bun run test:e2e`).
+> **Importante:** no template **Exemplo de CRUD**, execute `migration:run` antes de iniciar a API. No template **Padrão** não há migrations iniciais. Testes: **Bun** usa `bun test`; **npm/pnpm** usam **Vitest** (`npm run test`). Projetos gerados não incluem script `test:e2e` por padrão.
 
 ## Desenvolvimento local da CLI
 

--- a/libs/doc/site/README.md
+++ b/libs/doc/site/README.md
@@ -44,7 +44,9 @@ src/app/
 
 public/
 ├── CNAME           # nest.koalarx.com
-├── llms.txt        # índice para LLMs (gerado)
+├── llms.txt        # índice para LLMs — PT (gerado)
+├── llm.txt         # alias do índice PT (gerado)
+├── llms-en.txt     # índice EN (gerado)
 └── markdown/       # .md estáticos para Copy for AI (gerado)
 ```
 
@@ -56,7 +58,7 @@ O workflow `.github/workflows/deploy-docs.yml` na raiz do repositório faz build
 
 | Recurso | URL |
 |---------|-----|
-| Índice geral | `/llms.txt` (PT), `/llms-en.txt` (EN) |
+| Índice geral | `/llms.txt` e `/llm.txt` (PT), `/llms-en.txt` e `/llm-en.txt` (EN) |
 | Página específica | `/markdown/{locale}/{categoria}/{slug}.md` |
 
 O botão **Copy AI** no header copia a URL do índice. O **Copy for AI** em cada página copia a URL do Markdown correspondente.

--- a/libs/doc/site/angular.json
+++ b/libs/doc/site/angular.json
@@ -52,7 +52,15 @@
             "styles": [
               "src/styles.css",
               "src/theme/icons-minimal.css"
-            ]
+            ],
+            "server": "src/main.server.ts",
+            "outputMode": "static",
+            "security": {
+              "allowedHosts": []
+            },
+            "ssr": {
+              "entry": "src/server.ts"
+            }
           },
           "configurations": {
             "production": {
@@ -60,7 +68,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kB",
-                  "maximumError": "800kB"
+                  "maximumError": "850kB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/libs/doc/site/bun.lock
+++ b/libs/doc/site/bun.lock
@@ -9,8 +9,11 @@
         "@angular/compiler": "^21.1.0",
         "@angular/core": "^21.1.0",
         "@angular/platform-browser": "^21.1.0",
+        "@angular/platform-server": "^21.1.0",
         "@angular/router": "^21.1.0",
+        "@angular/ssr": "^21.2.15",
         "daisyui": "^5.5.23",
+        "express": "^5.1.0",
         "marked": "^18.0.5",
         "mermaid": "^11.12.0",
         "ngx-markdown": "^22.0.0",
@@ -25,6 +28,8 @@
         "@angular/compiler-cli": "^21.1.0",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.1",
+        "@types/express": "^5.0.1",
+        "@types/node": "^20.17.19",
         "jsdom": "^29.1.1",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.1",
@@ -86,7 +91,11 @@
 
     "@angular/platform-browser": ["@angular/platform-browser@21.2.17", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/animations": "21.2.17", "@angular/common": "21.2.17", "@angular/core": "21.2.17" }, "optionalPeers": ["@angular/animations"] }, "sha512-ROdSliejY37g1EphYmweYdm5cHM8HY3X4tbWt4ubxmhTyYgfN3nxrxfGQ/n7Mz5tDY9VXVLIGDgjLOGYOo4uTQ=="],
 
+    "@angular/platform-server": ["@angular/platform-server@21.2.17", "", { "dependencies": { "tslib": "^2.3.0", "xhr2": "^0.2.0" }, "peerDependencies": { "@angular/common": "21.2.17", "@angular/compiler": "21.2.17", "@angular/core": "21.2.17", "@angular/platform-browser": "21.2.17", "rxjs": "^6.5.3 || ^7.4.0" } }, "sha512-ll5mbZHyUjZp+aL5eFCcusZBMLYv2fbxuPAIhAHFpu55kC9zh7PFlbdINbr4kT/bjxYb4isw5nDbGj9+n+RHWg=="],
+
     "@angular/router": ["@angular/router@21.2.17", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "21.2.17", "@angular/core": "21.2.17", "@angular/platform-browser": "21.2.17", "rxjs": "^6.5.3 || ^7.4.0" } }, "sha512-RSCtK5ppAV6y6wfRLHSK2a9Wc/vm8j0wsC+/j9PH9yQmppWFVXDWsg5E39MKOIpnoYVx2+hI6eak6+wYtZTe1A=="],
+
+    "@angular/ssr": ["@angular/ssr@21.2.15", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "^21.0.0", "@angular/core": "^21.0.0", "@angular/platform-server": "^21.0.0", "@angular/router": "^21.0.0" }, "optionalPeers": ["@angular/platform-server"] }, "sha512-A6KMDGF2Olqvcb+Wn9t4zHnzGkrfYmHA2vGeKQeis9D1WJ5YEwqJv80BloxU1m/NdZBiZie8w+4MF/9RUEISXw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -518,7 +527,11 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -586,7 +599,23 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -1314,6 +1343,8 @@
 
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1347,6 +1378,8 @@
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xhr2": ["xhr2@0.2.1", "", {}, "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/libs/doc/site/package.json
+++ b/libs/doc/site/package.json
@@ -15,7 +15,8 @@
     "prestart": "node generate-icons.js",
     "prebuild": "node generate-icons.js",
     "build:dev": "node generate-icons.js && ng build --configuration development",
-    "build:prod": "node generate-icons.js && ng build --configuration production && node scripts/post-build.mjs"
+    "build:prod": "node generate-icons.js && ng build --configuration production && node scripts/post-build.mjs",
+    "serve:ssr:site": "node dist/site/server/server.mjs"
   },
   "prettier": {
     "printWidth": 100,
@@ -36,8 +37,11 @@
     "@angular/compiler": "^21.1.0",
     "@angular/core": "^21.1.0",
     "@angular/platform-browser": "^21.1.0",
+    "@angular/platform-server": "^21.1.0",
     "@angular/router": "^21.1.0",
+    "@angular/ssr": "^21.2.15",
     "daisyui": "^5.5.23",
+    "express": "^5.1.0",
     "marked": "^18.0.5",
     "mermaid": "^11.12.0",
     "ngx-markdown": "^22.0.0",
@@ -52,6 +56,8 @@
     "@angular/compiler-cli": "^21.1.0",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.1",
+    "@types/express": "^5.0.1",
+    "@types/node": "^20.17.19",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.1",

--- a/libs/doc/site/public/robots.txt
+++ b/libs/doc/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://nest.koalarx.com/sitemap.xml

--- a/libs/doc/site/src/app/app.config.server.ts
+++ b/libs/doc/site/src/app/app.config.server.ts
@@ -1,0 +1,12 @@
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(withRoutes(serverRoutes))
+  ]
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/libs/doc/site/src/app/app.config.ts
+++ b/libs/doc/site/src/app/app.config.ts
@@ -1,16 +1,23 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
-import { provideRouter, withInMemoryScrolling } from '@angular/router';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+  withInMemoryScrolling,
+} from '@angular/router';
 import { routes } from './app.routes';
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(
       routes,
+      withEnabledBlockingInitialNavigation(),
       withInMemoryScrolling({
         anchorScrolling: 'enabled',
         scrollPositionRestoration: 'enabled',
       }),
     ),
+    provideClientHydration(withEventReplay()),
   ],
 };

--- a/libs/doc/site/src/app/app.routes.server.ts
+++ b/libs/doc/site/src/app/app.routes.server.ts
@@ -1,0 +1,44 @@
+import { RenderMode, ServerRoute } from '@angular/ssr';
+import manifest from '../generated/docs-manifest.json';
+import type { DocsManifest } from './core/models/docs.types';
+
+const docsManifest = manifest as DocsManifest;
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: '',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: 'pt/docs',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: 'en/docs',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: ':locale',
+    renderMode: RenderMode.Prerender,
+    async getPrerenderParams() {
+      return docsManifest.supportedLocales.map((locale) => ({ locale }));
+    },
+  },
+  {
+    path: ':locale/docs/:category/:slug',
+    renderMode: RenderMode.Prerender,
+    async getPrerenderParams() {
+      return docsManifest.supportedLocales.flatMap((locale) =>
+        docsManifest.locales[locale].docs.map((doc) => ({
+          locale,
+          category: doc.category,
+          slug: doc.slug,
+        })),
+      );
+    },
+  },
+  {
+    path: '**',
+    renderMode: RenderMode.Client,
+  },
+];

--- a/libs/doc/site/src/app/app.routes.ts
+++ b/libs/doc/site/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { docMarkdownProviders } from './core/providers/doc-markdown.providers';
 import { localeGuard } from './core/guards/locale.guard';
+import { DocPageComponent } from './features/doc/doc-page.component';
 import { LandingPageComponent } from './features/landing/landing-page.component';
 
 export const routes: Routes = [
@@ -27,8 +28,7 @@ export const routes: Routes = [
   },
   {
     path: ':locale/docs/:category/:slug',
-    loadComponent: () =>
-      import('./features/doc/doc-page.component').then((module) => module.DocPageComponent),
+    component: DocPageComponent,
     canActivate: [localeGuard],
     providers: docMarkdownProviders,
   },

--- a/libs/doc/site/src/app/app.ts
+++ b/libs/doc/site/src/app/app.ts
@@ -1,15 +1,15 @@
-import { ViewportScroller } from '@angular/common';
+import { DOCUMENT, ViewportScroller } from '@angular/common';
 import { Component, computed, effect, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Meta, Title } from '@angular/platform-browser';
 import { NavigationEnd, Router, RouterOutlet, Scroll } from '@angular/router';
-import { filter, map } from 'rxjs';
+import { filter, map, startWith } from 'rxjs';
 import { DocsSidebarComponent } from './core/components/docs-sidebar/docs-sidebar.component';
 import { SearchDialogComponent } from './core/components/search-dialog/search-dialog.component';
 import { SiteFooterComponent } from './core/components/site-footer/site-footer.component';
 import { SiteHeaderComponent } from './core/components/site-header/site-header.component';
 import { UI_COPY } from './core/i18n/ui-copy';
 import { LocaleService } from './core/services/locale.service';
+import { SeoService } from './core/services/seo.service';
 
 @Component({
   selector: 'app-root',
@@ -24,15 +24,16 @@ import { LocaleService } from './core/services/locale.service';
 })
 export class App {
   private readonly router = inject(Router);
+  private readonly document = inject(DOCUMENT);
   private readonly viewportScroller = inject(ViewportScroller);
   private readonly localeService = inject(LocaleService);
-  private readonly meta = inject(Meta);
-  private readonly title = inject(Title);
+  private readonly seo = inject(SeoService);
 
   readonly isDocPage = toSignal(
     this.router.events.pipe(
       filter((event) => event instanceof NavigationEnd),
       map(() => this.localeService.isDocsUrl(this.router.url)),
+      startWith(this.localeService.isDocsUrl(this.router.url)),
     ),
     { initialValue: this.localeService.isDocsUrl(this.router.url) },
   );
@@ -51,17 +52,23 @@ export class App {
 
     effect(() => {
       const locale = this.localeService.locale();
-      document.documentElement.lang = locale === 'pt' ? 'pt-BR' : 'en';
-      this.meta.updateTag({
-        name: 'description',
-        content: UI_COPY[locale].metaDescription,
-      });
+      this.document.documentElement.lang = locale === 'pt' ? 'pt-BR' : 'en';
     });
 
-    effect(() => {
-      if (!this.isDocPage()) {
-        this.title.setTitle('Koala Nest');
+    this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+      if (this.localeService.isDocsUrl(this.router.url)) {
+        return;
       }
+
+      const locale = this.localeService.locale();
+      const copy = UI_COPY[locale];
+
+      this.seo.update({
+        title: copy.seo.landingTitle,
+        description: copy.metaDescription,
+        path: this.router.url.split('?')[0] || `/${locale}`,
+        locale,
+      });
     });
 
     this.router.events.pipe(filter((e): e is Scroll => e instanceof Scroll)).subscribe((e) => {

--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
@@ -63,6 +63,10 @@ export class DocOnThisPageComponent implements OnDestroy {
   private setupObserver(root: HTMLElement, nextItems: TocItem[]) {
     this.observer?.disconnect();
 
+    if (typeof IntersectionObserver === 'undefined') {
+      return;
+    }
+
     this.observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {

--- a/libs/doc/site/src/app/core/components/markdown-content/markdown-content.component.ts
+++ b/libs/doc/site/src/app/core/components/markdown-content/markdown-content.component.ts
@@ -1,3 +1,4 @@
+import { isPlatformBrowser } from '@angular/common';
 import {
   Component,
   effect,
@@ -6,6 +7,7 @@ import {
   inject,
   input,
   output,
+  PLATFORM_ID,
   signal,
   untracked,
 } from '@angular/core';
@@ -32,6 +34,7 @@ import { ensurePrismLoaded, highlightCodeBlocks } from '../../utils/prism-loader
 })
 export class MarkdownContentComponent {
   private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   readonly content = input.required<string>();
   readonly rendered = output<void>();
@@ -64,7 +67,9 @@ export class MarkdownContentComponent {
   }
 
   onReady() {
-    this.highlightCode();
+    if (this.isBrowser) {
+      this.highlightCode();
+    }
     queueMicrotask(() => this.rendered.emit());
   }
 
@@ -78,10 +83,12 @@ export class MarkdownContentComponent {
     const usesMermaid = contentHasMermaid(content);
     this.usesMermaid.set(usesMermaid);
 
-    await ensurePrismLoaded();
+    if (this.isBrowser) {
+      await ensurePrismLoaded();
 
-    if (usesMermaid) {
-      await ensureMermaidLoaded();
+      if (usesMermaid) {
+        await ensureMermaidLoaded();
+      }
     }
 
     this.renderMarkdown.set(true);

--- a/libs/doc/site/src/app/core/components/site-header/site-header.component.ts
+++ b/libs/doc/site/src/app/core/components/site-header/site-header.component.ts
@@ -7,6 +7,7 @@ import { UI_COPY } from '../../i18n/ui-copy';
 import { CopyFeedbackButtonComponent } from '../copy-feedback-button/copy-feedback-button.component';
 import { DocsSidebarComponent } from '../docs-sidebar/docs-sidebar.component';
 import { GithubStarsComponent } from '../github-stars/github-stars.component';
+import { absoluteSiteUrl } from '../../config/site-seo';
 import { LocaleService } from '../../services/locale.service';
 import { SearchService } from '../../services/search.service';
 
@@ -37,7 +38,7 @@ export class SiteHeaderComponent {
 
   readonly homeLink = computed(() => this.localeService.homeRoute());
   readonly docsNavLink = computed(() => this.localeService.docsRootRoute());
-  readonly llmsUrl = () => `${location.origin}${this.localeService.llmsFile()}`;
+  readonly llmsUrl = () => absoluteSiteUrl(this.localeService.llmsFile());
 
   switchLocale(target: 'pt' | 'en') {
     if (target === this.localeService.locale()) return;

--- a/libs/doc/site/src/app/core/config/site-seo.ts
+++ b/libs/doc/site/src/app/core/config/site-seo.ts
@@ -1,0 +1,11 @@
+export const SITE_URL = 'https://nest.koalarx.com';
+export const SITE_NAME = 'Koala Nest';
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/logo.svg`;
+
+export function absoluteSiteUrl(path: string) {
+  if (!path || path === '/') {
+    return SITE_URL;
+  }
+
+  return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/libs/doc/site/src/app/core/i18n/ui-copy.ts
+++ b/libs/doc/site/src/app/core/i18n/ui-copy.ts
@@ -17,6 +17,9 @@ export const UI_COPY = {
     onThisPage: 'Nesta página',
     metaDescription:
       'Facilitador para APIs NestJS com DDD e TypeORM. A CLI copia módulos prontos para o seu repositório.',
+    seo: {
+      landingTitle: 'Koala Nest — APIs NestJS com DDD e TypeORM',
+    },
     footer: {
       description:
         'Facilitador para criar APIs NestJS com arquitetura DDD. Código copiado para o seu repositório — legível, adaptável e sob seu controle.',
@@ -28,6 +31,7 @@ export const UI_COPY = {
       quickCommandsList: [
         'bun install -g @koalarx/nest',
         'kl-nest new',
+        'kl-nest add cache',
         'bun run migration:run  # template CRUD',
         'kl-nest --help',
       ],
@@ -84,7 +88,7 @@ export const UI_COPY = {
       {
         title: 'Scaffolding inteligente',
         description:
-          'Fluxo interativo para nome, gerenciador de pacotes (Bun recomendado), template e opções futuras de autenticação.',
+          'Fluxo interativo para nome, gerenciador de pacotes (Bun recomendado), template, autenticação (JWT/OAuth2) e extras (cache, health, cron, eventos). API Key em breve.',
       },
       {
         title: 'Templates úteis',
@@ -126,6 +130,9 @@ export const UI_COPY = {
     onThisPage: 'On this page',
     metaDescription:
       'A facilitator for building NestJS APIs with DDD and TypeORM. The CLI copies modules into your repository.',
+    seo: {
+      landingTitle: 'Koala Nest — NestJS APIs with DDD and TypeORM',
+    },
     footer: {
       description:
         'A facilitator for building NestJS APIs with DDD architecture. Code copied into your repository — readable, adaptable, and under your control.',
@@ -137,6 +144,7 @@ export const UI_COPY = {
       quickCommandsList: [
         'bun install -g @koalarx/nest',
         'kl-nest new',
+        'kl-nest add cache',
         'bun run migration:run  # CRUD template',
         'kl-nest --help',
       ],
@@ -193,7 +201,7 @@ export const UI_COPY = {
       {
         title: 'Smart Scaffolding',
         description:
-          'Interactive flow for project name, package manager (Bun recommended), template, and future auth options.',
+          'Interactive flow for project name, package manager (Bun recommended), template, auth (JWT/OAuth2), and extras (cache, health, cron, events). API Key coming soon.',
       },
       {
         title: 'Useful Templates',

--- a/libs/doc/site/src/app/core/services/locale.service.ts
+++ b/libs/doc/site/src/app/core/services/locale.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
-import { filter, map } from 'rxjs';
+import { filter, map, startWith } from 'rxjs';
 import manifest from '../../../generated/docs-manifest.json';
 import { DEFAULT_LOCALE, type Locale, SUPPORTED_LOCALES } from '../models/locale.types';
 import type { DocsManifest } from '../models/docs.types';
@@ -26,6 +26,7 @@ export class LocaleService {
     this.router.events.pipe(
       filter((event) => event instanceof NavigationEnd),
       map(() => this.parseLocale(this.router.url)),
+      startWith(this.parseLocale(this.router.url)),
     ),
     { initialValue: this.parseLocale(this.router.url) },
   );

--- a/libs/doc/site/src/app/core/services/seo.service.ts
+++ b/libs/doc/site/src/app/core/services/seo.service.ts
@@ -1,0 +1,86 @@
+import { DOCUMENT } from '@angular/common';
+import { inject, Injectable } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+import type { Locale } from '../models/locale.types';
+import { absoluteSiteUrl, DEFAULT_OG_IMAGE, SITE_NAME } from '../config/site-seo';
+
+export interface PageSeo {
+  title: string;
+  description: string;
+  path: string;
+  locale: Locale;
+  alternatePath?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SeoService {
+  private readonly title = inject(Title);
+  private readonly meta = inject(Meta);
+  private readonly document = inject(DOCUMENT);
+
+  update(page: PageSeo) {
+    const url = absoluteSiteUrl(page.path);
+    const fullTitle = page.title.includes(SITE_NAME) ? page.title : `${page.title} — ${SITE_NAME}`;
+
+    this.title.setTitle(fullTitle);
+    this.meta.updateTag({ name: 'description', content: page.description });
+    this.meta.updateTag({ name: 'robots', content: 'index, follow' });
+
+    this.meta.updateTag({ property: 'og:title', content: fullTitle });
+    this.meta.updateTag({ property: 'og:description', content: page.description });
+    this.meta.updateTag({ property: 'og:url', content: url });
+    this.meta.updateTag({ property: 'og:type', content: 'website' });
+    this.meta.updateTag({ property: 'og:site_name', content: SITE_NAME });
+    this.meta.updateTag({ property: 'og:image', content: DEFAULT_OG_IMAGE });
+    this.meta.updateTag({
+      property: 'og:locale',
+      content: page.locale === 'pt' ? 'pt_BR' : 'en_US',
+    });
+
+    this.meta.updateTag({ name: 'twitter:card', content: 'summary' });
+    this.meta.updateTag({ name: 'twitter:title', content: fullTitle });
+    this.meta.updateTag({ name: 'twitter:description', content: page.description });
+    this.meta.updateTag({ name: 'twitter:image', content: DEFAULT_OG_IMAGE });
+
+    this.setLinkTag('canonical', url);
+    this.setAlternateLinks(page.path, page.alternatePath);
+  }
+
+  private setLinkTag(rel: string, href: string) {
+    const selector = `link[rel="${rel}"]`;
+    let link = this.document.head.querySelector(selector) as HTMLLinkElement | null;
+
+    if (!link) {
+      link = this.document.createElement('link');
+      link.rel = rel;
+      this.document.head.appendChild(link);
+    }
+
+    link.href = href;
+  }
+
+  private setAlternateLinks(currentPath: string, alternatePath?: string) {
+    this.document.head
+      .querySelectorAll('link[rel="alternate"][hreflang]')
+      .forEach((node) => node.remove());
+
+    if (!alternatePath) {
+      return;
+    }
+
+    const ptPath = currentPath.startsWith('/en') ? alternatePath : currentPath;
+    const enPath = currentPath.startsWith('/en') ? currentPath : alternatePath;
+
+    for (const [hreflang, href] of [
+      ['pt-BR', absoluteSiteUrl(ptPath)],
+      ['en', absoluteSiteUrl(enPath)],
+      ['x-default', absoluteSiteUrl(ptPath)],
+    ] as const) {
+      const link = this.document.createElement('link');
+      link.rel = 'alternate';
+      link.hreflang = hreflang;
+      link.href = href;
+      this.document.head.appendChild(link);
+    }
+  }
+}

--- a/libs/doc/site/src/app/core/utils/prism-loader.ts
+++ b/libs/doc/site/src/app/core/utils/prism-loader.ts
@@ -17,6 +17,10 @@ export function ensurePrismLoaded() {
 }
 
 export function highlightCodeBlocks(root: ParentNode) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
   const prism = (window as Window & { Prism?: { highlightElement: (element: HTMLElement) => void } })
     .Prism;
   if (!prism) return;

--- a/libs/doc/site/src/app/features/doc/doc-page.component.ts
+++ b/libs/doc/site/src/app/features/doc/doc-page.component.ts
@@ -1,14 +1,15 @@
+import { isPlatformBrowser } from '@angular/common';
 import {
   Component,
   computed,
   effect,
   ElementRef,
   inject,
+  PLATFORM_ID,
   signal,
   viewChild,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { map } from 'rxjs';
 import { CopyFeedbackButtonComponent } from '../../core/components/copy-feedback-button/copy-feedback-button.component';
@@ -16,7 +17,9 @@ import { DocOnThisPageComponent } from '../../core/components/doc-on-this-page/d
 import { MarkdownContentComponent } from '../../core/components/markdown-content/markdown-content.component';
 import { UI_COPY } from '../../core/i18n/ui-copy';
 import { DocsService } from '../../core/services/docs.service';
+import { absoluteSiteUrl } from '../../core/config/site-seo';
 import { LocaleService } from '../../core/services/locale.service';
+import { SeoService } from '../../core/services/seo.service';
 
 @Component({
   selector: 'app-doc-page',
@@ -27,7 +30,8 @@ export class DocPageComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly docsService = inject(DocsService);
   private readonly localeService = inject(LocaleService);
-  private readonly title = inject(Title);
+  private readonly seo = inject(SeoService);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   private readonly articleRef = viewChild<ElementRef<HTMLElement>>('articleRef');
   private previousDocKey = '';
@@ -59,13 +63,23 @@ export class DocPageComponent {
   readonly docAiUrl = () => {
     const current = this.doc();
     if (!current?.mdRel) return '';
-    return `${location.origin}/markdown/${current.mdRel}`;
+    return absoluteSiteUrl(`/markdown/${current.mdRel}`);
   };
 
   constructor() {
     effect(() => {
       const page = this.doc();
-      this.title.setTitle(page ? `${page.title} — Koala Nest` : 'Koala Nest');
+      if (!page) {
+        return;
+      }
+
+      this.seo.update({
+        title: page.title,
+        description: page.description || UI_COPY[this.localeService.locale()].metaDescription,
+        path: page.route,
+        locale: this.localeService.locale(),
+        alternatePath: page.alternateRoute,
+      });
     });
 
     effect(() => {
@@ -78,7 +92,7 @@ export class DocPageComponent {
 
       this.markdownReady.set(0);
 
-      if (isDocChange) {
+      if (isDocChange && this.isBrowser) {
         queueMicrotask(() => window.scrollTo({ top: 0, left: 0 }));
       }
     });

--- a/libs/doc/site/src/app/shared/components/button/button.ts
+++ b/libs/doc/site/src/app/shared/components/button/button.ts
@@ -70,7 +70,7 @@ export class Button {
     effect(() => {
       const button = this.elementRef.nativeElement;
 
-      for (const key of button.classList) {
+      for (const key of Array.from(button.classList)) {
         if (key.startsWith('btn')) {
           button.classList.remove(key);
         }

--- a/libs/doc/site/src/index.html
+++ b/libs/doc/site/src/index.html
@@ -9,6 +9,26 @@
       name="description"
       content="Facilitador para APIs NestJS com DDD e TypeORM. A CLI copia módulos prontos para o seu repositório."
     />
+    <meta name="robots" content="index, follow" />
+    <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large" />
+    <link rel="canonical" href="https://nest.koalarx.com/" />
+    <meta property="og:site_name" content="Koala Nest" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nest.koalarx.com/" />
+    <meta property="og:title" content="Koala Nest — APIs NestJS com DDD e TypeORM" />
+    <meta
+      property="og:description"
+      content="Facilitador para APIs NestJS com DDD e TypeORM. A CLI copia módulos prontos para o seu repositório."
+    />
+    <meta property="og:image" content="https://nest.koalarx.com/logo.svg" />
+    <meta property="og:locale" content="pt_BR" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Koala Nest — APIs NestJS com DDD e TypeORM" />
+    <meta
+      name="twitter:description"
+      content="Facilitador para APIs NestJS com DDD e TypeORM. A CLI copia módulos prontos para o seu repositório."
+    />
+    <meta name="twitter:image" content="https://nest.koalarx.com/logo.svg" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/libs/doc/site/src/main.server.ts
+++ b/libs/doc/site/src/main.server.ts
@@ -1,0 +1,8 @@
+import { BootstrapContext, bootstrapApplication } from '@angular/platform-browser';
+import { App } from './app/app';
+import { config } from './app/app.config.server';
+
+const bootstrap = (context: BootstrapContext) =>
+    bootstrapApplication(App, config, context);
+
+export default bootstrap;

--- a/libs/doc/site/src/server.ts
+++ b/libs/doc/site/src/server.ts
@@ -1,0 +1,68 @@
+import {
+  AngularNodeAppEngine,
+  createNodeRequestHandler,
+  isMainModule,
+  writeResponseToNodeResponse,
+} from '@angular/ssr/node';
+import express from 'express';
+import { join } from 'node:path';
+
+const browserDistFolder = join(import.meta.dirname, '../browser');
+
+const app = express();
+const angularApp = new AngularNodeAppEngine();
+
+/**
+ * Example Express Rest API endpoints can be defined here.
+ * Uncomment and define endpoints as necessary.
+ *
+ * Example:
+ * ```ts
+ * app.get('/api/{*splat}', (req, res) => {
+ *   // Handle API request
+ * });
+ * ```
+ */
+
+/**
+ * Serve static files from /browser
+ */
+app.use(
+  express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: false,
+    redirect: false,
+  }),
+);
+
+/**
+ * Handle all other requests by rendering the Angular application.
+ */
+app.use((req, res, next) => {
+  angularApp
+    .handle(req)
+    .then((response) =>
+      response ? writeResponseToNodeResponse(response, res) : next(),
+    )
+    .catch(next);
+});
+
+/**
+ * Start the server if this module is the main entry point, or it is ran via PM2.
+ * The server listens on the port defined by the `PORT` environment variable, or defaults to 4000.
+ */
+if (isMainModule(import.meta.url) || process.env['pm_id']) {
+  const port = process.env['PORT'] || 4000;
+  app.listen(port, (error) => {
+    if (error) {
+      throw error;
+    }
+
+    console.log(`Node Express server listening on http://localhost:${port}`);
+  });
+}
+
+/**
+ * Request handler used by the Angular CLI (for dev-server and during build) or Firebase Cloud Functions.
+ */
+export const reqHandler = createNodeRequestHandler(app);

--- a/libs/doc/site/tsconfig.app.json
+++ b/libs/doc/site/tsconfig.app.json
@@ -4,7 +4,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": [],
+    "types": [
+      "node"
+    ],
     "resolveJsonModule": true
   },
   "include": [

--- a/scripts/build-doc-manifest.mjs
+++ b/scripts/build-doc-manifest.mjs
@@ -18,6 +18,7 @@ const prerenderRoutesPath = path.join(docRoot, 'site/prerender-routes.txt');
 const txtRoot = path.join(docRoot, 'txt');
 const publicRoot = path.join(docRoot, 'site/public');
 const publicMarkdownRoot = path.join(publicRoot, 'markdown');
+const SITE_URL = 'https://nest.koalarx.com';
 
 function extractHeadings(body) {
   const headings = [];
@@ -129,6 +130,24 @@ function copyMarkdownDir(src, dest) {
   }
 }
 
+function buildSitemap(routes) {
+  const uniqueRoutes = [...new Set(routes.filter(Boolean))];
+  const urls = uniqueRoutes
+    .map((route) => {
+      const loc = route === '/' ? SITE_URL : `${SITE_URL}${route}`;
+      return `  <url>\n    <loc>${loc}</loc>\n  </url>`;
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urls,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
 function syncMarkdownToPublic() {
   if (fs.existsSync(publicMarkdownRoot)) {
     fs.rmSync(publicMarkdownRoot, { recursive: true, force: true });
@@ -210,6 +229,7 @@ const prerenderRoutes = [
   ]),
 ];
 fs.writeFileSync(prerenderRoutesPath, `${prerenderRoutes.join('\n')}\n`);
+fs.writeFileSync(path.join(publicRoot, 'sitemap.xml'), buildSitemap(prerenderRoutes));
 
 fs.mkdirSync(txtRoot, { recursive: true });
 fs.mkdirSync(publicRoot, { recursive: true });
@@ -228,3 +248,4 @@ for (const locale of supportedLocales) {
 const totalDocs = Object.values(locales).reduce((sum, l) => sum + l.docs.length, 0);
 console.log(`Manifest gerado: ${totalDocs} tópicos (${supportedLocales.join(', ')}) → ${manifestPath}`);
 console.log(`Markdown publicado: ${markdownFiles} arquivos → ${publicMarkdownRoot}`);
+console.log(`Sitemap gerado → ${path.join(publicRoot, 'sitemap.xml')}`);


### PR DESCRIPTION
## Summary
- Adiciona prerender estático (SSG) com 59 rotas de documentação renderizadas no HTML
- Implementa SEO por página (title, description, canonical, Open Graph, Twitter, hreflang)
- Inclui `robots.txt` e geração de `sitemap.xml` no build
- Corrige erros de SSR (`document`, `window`, Prism, IntersectionObserver) que impediam o conteúdo de aparecer no HTML estático
- Atualiza README e guias de instalação/OpenAPI desatualizados

## Test plan
- [x] `bun run build:docs` — 59 rotas prerenderizadas sem erros
- [x] `bun run test:unit` — 22 testes passando
- [x] HTML de `/pt/docs/inicio/guia-de-instalacao` contém título, canonical e conteúdo markdown
- [ ] Após deploy: verificar `https://nest.koalarx.com/robots.txt` e `https://nest.koalarx.com/sitemap.xml`
- [ ] Enviar sitemap no Google Search Console


Made with [Cursor](https://cursor.com)