### PR TITLE
release: 4.0.6 — E2E nos projetos, doc sincronizada e fix AutoMapper

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'libs/doc/**'
+      - 'package.json'
       - 'scripts/build-doc-manifest.mjs'
       - '.github/workflows/deploy-docs.yml'
 

--- a/libs/cli/commands/new/configure-test-runner.ts
+++ b/libs/cli/commands/new/configure-test-runner.ts
@@ -13,8 +13,27 @@ export function configureTestRunner(
     return;
   }
 
-  scripts.test = 'vitest run';
-  scripts['test:watch'] = 'vitest';
+  scripts.test = 'vitest run --config vitest.config.ts';
+  scripts['test:watch'] = 'vitest --config vitest.config.ts';
   devDependencies.vitest = '^4.1.8';
   devDependencies['vite-tsconfig-paths'] = '^5.1.4';
+}
+
+export function configureE2ETestRunner(
+  packageJson: Record<string, unknown>,
+  packageManager: PackageManager,
+) {
+  const scripts = packageJson.scripts as Record<string, string>;
+  const devDependencies = packageJson.devDependencies as Record<string, string>;
+
+  devDependencies.supertest ??= '^7.1.0';
+  devDependencies['@types/supertest'] ??= '^6.0.2';
+
+  if (packageManager === 'bun') {
+    scripts['test:e2e'] =
+      'bun test --preload ./src/test/setup-e2e.ts src/test/host/controllers/';
+    return;
+  }
+
+  scripts['test:e2e'] = 'vitest run --config vitest.config.e2e.ts';
 }

--- a/libs/cli/commands/new/create-ddd-structure.ts
+++ b/libs/cli/commands/new/create-ddd-structure.ts
@@ -4,7 +4,7 @@ import { DDD_LAYER_FOLDERS } from '@cli/constants/domain';
 import { patchGeneratedProjectConfig } from '@cli/utils/patch-generated-project.ts';
 import { runCommand } from '@cli/utils/run-command';
 import type { PackageManager } from '@cli/types';
-import { configureTestRunner } from './configure-test-runner.ts';
+import { configureE2ETestRunner, configureTestRunner } from './configure-test-runner.ts';
 
 export async function createDDDStructure(
   projectName: string,
@@ -63,16 +63,14 @@ export async function createDDDStructure(
   packageJson.devDependencies ??= {};
 
   configureTestRunner(packageJson, packageManager);
+  configureE2ETestRunner(packageJson, packageManager);
 
   delete packageJson.scripts['test:cov'];
   delete packageJson.scripts['test:debug'];
-  delete packageJson.scripts['test:e2e'];
   delete packageJson.jest;
 
   delete packageJson.devDependencies['@types/jest'];
-  delete packageJson.devDependencies['@types/supertest'];
   delete packageJson.devDependencies['ts-jest'];
-  delete packageJson.devDependencies['supertest'];
 
   writeFileSync(
     path.join(process.cwd(), projectName, 'package.json'),

--- a/libs/cli/constants/cli-project-checklist.ts
+++ b/libs/cli/constants/cli-project-checklist.ts
@@ -18,6 +18,25 @@ export type ProjectExpectation = {
   eventJobs: boolean;
 };
 
+/** Infraestrutura E2E presente em todo projeto gerado. */
+export const E2E_INFRA_PATHS = [
+  'src/test/setup-e2e.ts',
+  'src/test/create-e2e-test-app.ts',
+  'src/test/e2e-context.ts',
+  'src/test/utils/create-e2e-database.ts',
+  'src/test/utils/e2e-database-client.ts',
+  'src/test/host/controllers/app/app.e2e.spec.ts',
+] as const;
+
+/** Exemplos E2E do template CRUD (Person + auth). */
+export const CRUD_E2E_EXAMPLE_PATHS = [
+  'src/test/host/controllers/person/person.controller.e2e.spec.ts',
+  'src/test/host/controllers/person/lazy-loading.e2e.spec.ts',
+  'src/test/host/controllers/auth/auth.controller.e2e.spec.ts',
+  'src/test/app-auth-test.module.ts',
+  'src/test/create-auth-e2e-test-app.ts',
+] as const;
+
 /** Workspace pronto para abrir no VS Code e subir a API. */
 export const WORKSPACE_SETUP_PATHS = [
   '.vscode/launch.json',
@@ -230,10 +249,14 @@ export function buildProjectExpectation(
 export function requiredPathsForExpectation(
   expectation: ProjectExpectation,
 ): readonly string[] {
-  const paths: string[] = [...CORE_REQUIRED_PATHS, ...WORKSPACE_SETUP_PATHS];
+  const paths: string[] = [
+    ...CORE_REQUIRED_PATHS,
+    ...WORKSPACE_SETUP_PATHS,
+    ...E2E_INFRA_PATHS,
+  ];
 
   if (expectation.template === Template.CRUD_SAMPLE) {
-    paths.push(...CRUD_TEMPLATE_REQUIRED_PATHS);
+    paths.push(...CRUD_TEMPLATE_REQUIRED_PATHS, ...CRUD_E2E_EXAMPLE_PATHS);
   }
 
   if (expectation.cache === 'redis') {
@@ -265,7 +288,7 @@ export function forbiddenPathsForExpectation(
   const paths: string[] = [];
 
   if (expectation.template === Template.DEFAULT) {
-    paths.push(...DEFAULT_TEMPLATE_FORBIDDEN_PATHS);
+    paths.push(...DEFAULT_TEMPLATE_FORBIDDEN_PATHS, ...CRUD_E2E_EXAMPLE_PATHS);
   } else {
     paths.push(...CRUD_TEMPLATE_FORBIDDEN_PATHS);
   }

--- a/libs/cli/test/unit/configure-test-runner.spec.ts
+++ b/libs/cli/test/unit/configure-test-runner.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { configureTestRunner } from '@cli/commands/new/configure-test-runner.ts';
+import {
+  configureE2ETestRunner,
+  configureTestRunner,
+} from '@cli/commands/new/configure-test-runner.ts';
 
 describe('configureTestRunner', () => {
   it('configura Bun test para projetos com bun', () => {
@@ -23,9 +26,39 @@ describe('configureTestRunner', () => {
 
     configureTestRunner(packageJson, 'npm');
 
-    expect(packageJson.scripts.test).toBe('vitest run');
-    expect(packageJson.scripts['test:watch']).toBe('vitest');
+    expect(packageJson.scripts.test).toBe('vitest run --config vitest.config.ts');
+    expect(packageJson.scripts['test:watch']).toBe('vitest --config vitest.config.ts');
     expect(packageJson.devDependencies.vitest).toBe('^4.1.8');
     expect(packageJson.devDependencies['vite-tsconfig-paths']).toBe('^5.1.4');
+  });
+});
+
+describe('configureE2ETestRunner', () => {
+  it('configura Bun E2E com preload do setup-e2e', () => {
+    const packageJson = {
+      scripts: {} as Record<string, string>,
+      devDependencies: {} as Record<string, string>,
+    };
+
+    configureE2ETestRunner(packageJson, 'bun');
+
+    expect(packageJson.scripts['test:e2e']).toBe(
+      'bun test --preload ./src/test/setup-e2e.ts src/test/host/controllers/',
+    );
+    expect(packageJson.devDependencies.supertest).toBe('^7.1.0');
+  });
+
+  it('configura Vitest E2E para npm e pnpm', () => {
+    const packageJson = {
+      scripts: {} as Record<string, string>,
+      devDependencies: {} as Record<string, string>,
+    };
+
+    configureE2ETestRunner(packageJson, 'pnpm');
+
+    expect(packageJson.scripts['test:e2e']).toBe(
+      'vitest run --config vitest.config.e2e.ts',
+    );
+    expect(packageJson.devDependencies['@types/supertest']).toBe('^6.0.2');
   });
 });

--- a/libs/cli/test/unit/patch-app-test-module.spec.ts
+++ b/libs/cli/test/unit/patch-app-test-module.spec.ts
@@ -1,0 +1,39 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { patchAppTestModuleForDefault } from '@cli/utils/patch-app-test-module.ts';
+
+describe('patchAppTestModuleForDefault', () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  it('usa InfraModule no AppTestModule do template padrão', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-app-test-'));
+    mkdirSync(path.join(tempDir, 'src/test'), { recursive: true });
+
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      patchAppTestModuleForDefault('.');
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const content = readFileSync(
+      path.join(tempDir, 'src/test/app-test.module.ts'),
+      'utf8',
+    );
+
+    expect(content).toContain('InfraModule');
+    expect(content).not.toContain('PersonModule');
+    expect(content).toContain('e2eDatabaseUrl');
+  });
+});

--- a/libs/cli/utils/install-module.ts
+++ b/libs/cli/utils/install-module.ts
@@ -327,6 +327,15 @@ export async function installModule(
         );
       }
 
+      if (packageManager !== 'bun') {
+        for (const configFile of ['vitest.config.ts', 'vitest.config.e2e.ts']) {
+          cpSync(
+            path.join(getSourceCodePath(), configFile),
+            path.join(projectPath, configFile),
+          );
+        }
+      }
+
       patchInfraModuleFile(projectName, false);
       patchMainFile(projectName, stripMainOptionalFeatures);
 

--- a/libs/cli/utils/install-workspace-config.ts
+++ b/libs/cli/utils/install-workspace-config.ts
@@ -90,6 +90,8 @@ export function installWorkspaceConfig(
         task.command = runScriptCommand(packageManager, 'start:dev');
       } else if (task.command.includes('test')) {
         task.command = runScriptCommand(packageManager, 'test');
+      } else if (task.command.includes('test:e2e')) {
+        task.command = runScriptCommand(packageManager, 'test:e2e');
       } else if (task.command.includes('migration:run')) {
         task.command = runScriptCommand(packageManager, 'migration:run');
       }

--- a/libs/cli/utils/patch-app-test-module.ts
+++ b/libs/cli/utils/patch-app-test-module.ts
@@ -1,0 +1,34 @@
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { resolveProjectPath } from './resolve-project-path';
+
+const defaultAppTestModule = `import { envSchema } from '@/core/env';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { InfraModule } from '@/infra/infra.module';
+import { e2eDatabaseUrl } from '@/test/e2e-context';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      ignoreEnvFile: true,
+      validate: () =>
+        envSchema.parse({
+          PORT: 3000,
+          NODE_ENV: 'test',
+          DATABASE_URL: e2eDatabaseUrl,
+        }),
+    }),
+    InfraModule,
+  ],
+})
+export class AppTestModule {}
+`;
+
+export function patchAppTestModuleForDefault(projectName: string): void {
+  writeFileSync(
+    path.join(resolveProjectPath(projectName), 'src/test/app-test.module.ts'),
+    defaultAppTestModule,
+  );
+}

--- a/libs/cli/utils/remove-sample-parts.ts
+++ b/libs/cli/utils/remove-sample-parts.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { removeImportLines } from './project-files';
 import { patchAppModuleJobs } from './patch-jobs-module';
+import { patchAppTestModuleForDefault } from './patch-app-test-module';
 import { resolveProjectPath } from './resolve-project-path';
 import { stripMainOptionalFeatures } from './patch-main';
 import { stripDefineDocumentationAuth } from './patch-define-documentation';
@@ -88,11 +89,14 @@ const partsToRemove: PartsToRemove[] = [
   },
 ];
 
-const defaultTemplatePathsToRemove = [
+const defaultSampleTestPathsToRemove = [
   'src/test/application',
   'src/test/mockup/person',
   'src/test/host/controllers/person/person.controller.e2e.spec.ts',
   'src/test/host/controllers/person/lazy-loading.e2e.spec.ts',
+];
+
+const defaultAuthE2ePathsToRemove = [
   'src/test/host/controllers/auth/auth.controller.e2e.spec.ts',
   'src/test/app-auth-test.module.ts',
   'src/test/create-auth-e2e-test-app.ts',
@@ -166,8 +170,12 @@ export async function removeSampleParts(projectName: string) {
   }
 
   patchAppModuleJobs(projectName, { eventHandlers: [], cronJobs: [] });
+  patchAppTestModuleForDefault(projectName);
 
-  removePaths(projectName, defaultTemplatePathsToRemove);
+  removePaths(projectName, [
+    ...defaultSampleTestPathsToRemove,
+    ...defaultAuthE2ePathsToRemove,
+  ]);
 }
 
 export async function cleanDefaultTemplateWithoutAuth(projectName: string) {

--- a/libs/doc/markdown/en/getting-started/installation-guide.md
+++ b/libs/doc/markdown/en/getting-started/installation-guide.md
@@ -122,6 +122,7 @@ bun run start:dev
 bun run start:prod
 bun test
 bun test --watch
+bun run test:e2e
 bun run migration:generate
 bun run migration:run
 bun run migration:revert
@@ -134,6 +135,7 @@ npm run start:dev
 npm run start:prod
 npm run test
 npm run test:watch
+npm run test:e2e
 npm run migration:generate
 npm run migration:run
 npm run migration:revert
@@ -146,12 +148,13 @@ pnpm run start:dev
 pnpm run start:prod
 pnpm run test
 pnpm run test:watch
+pnpm run test:e2e
 pnpm run migration:generate
 pnpm run migration:run
 pnpm run migration:revert
 ```
 
-> **Important:** with the **CRUD Example** template, run `migration:run` before starting the API. The **Default** template has no initial migrations. Tests: **Bun** uses `bun test`; **npm/pnpm** use **Vitest** (`npm run test`). Generated projects do not include a `test:e2e` script by default.
+> **Important:** with the **CRUD Example** template, run `migration:run` before starting the API. The **Default** template has no initial migrations. Unit tests: **Bun** uses `bun test`; **npm/pnpm** use **Vitest** (`npm run test`). **E2E:** every project includes `test:e2e` and infrastructure under `src/test/` (`setup-e2e.ts`, `create-e2e-test-app.ts`, ephemeral Postgres database). The **Default** template ships a minimal `app.e2e.spec.ts`; **CRUD** adds full Person and auth examples under `src/test/host/controllers/`. Requires `DATABASE_URL` pointing to a local Postgres instance.
 
 ## Local CLI development
 

--- a/libs/doc/markdown/pt/inicio/guia-de-instalacao.md
+++ b/libs/doc/markdown/pt/inicio/guia-de-instalacao.md
@@ -122,6 +122,7 @@ bun run start:dev
 bun run start:prod
 bun test
 bun test --watch
+bun run test:e2e
 bun run migration:generate
 bun run migration:run
 bun run migration:revert
@@ -134,6 +135,7 @@ npm run start:dev
 npm run start:prod
 npm run test
 npm run test:watch
+npm run test:e2e
 npm run migration:generate
 npm run migration:run
 npm run migration:revert
@@ -146,12 +148,13 @@ pnpm run start:dev
 pnpm run start:prod
 pnpm run test
 pnpm run test:watch
+pnpm run test:e2e
 pnpm run migration:generate
 pnpm run migration:run
 pnpm run migration:revert
 ```
 
-> **Importante:** no template **Exemplo de CRUD**, execute `migration:run` antes de iniciar a API. No template **Padrão** não há migrations iniciais. Testes: **Bun** usa `bun test`; **npm/pnpm** usam **Vitest** (`npm run test`). Projetos gerados não incluem script `test:e2e` por padrão.
+> **Importante:** no template **Exemplo de CRUD**, execute `migration:run` antes de iniciar a API. No template **Padrão** não há migrations iniciais. Testes unitários: **Bun** usa `bun test`; **npm/pnpm** usam **Vitest** (`npm run test`). **E2E:** todo projeto inclui `test:e2e` e a infraestrutura em `src/test/` (`setup-e2e.ts`, `create-e2e-test-app.ts`, banco Postgres efêmero). O template **Padrão** traz `app.e2e.spec.ts` mínimo; o **CRUD** inclui exemplos completos de Person e auth em `src/test/host/controllers/`. Requer `DATABASE_URL` apontando para Postgres local.
 
 ## Desenvolvimento local da CLI
 

--- a/libs/doc/site/src/app/core/constants/app-version.ts
+++ b/libs/doc/site/src/app/core/constants/app-version.ts
@@ -1,1 +1,2 @@
-export const APP_VERSION = '4.0.0';
+// Gerado por scripts/build-doc-manifest.mjs — não editar manualmente.
+export const APP_VERSION = '4.0.6';

--- a/libs/doc/site/src/app/core/constants/app-version.unit.spec.ts
+++ b/libs/doc/site/src/app/core/constants/app-version.unit.spec.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { APP_VERSION } from './app-version';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../../../',
+);
+
+describe('APP_VERSION', () => {
+  it('reflete a versão publicada da CLI no package.json raiz', () => {
+    const rootPackage = JSON.parse(
+      readFileSync(path.join(repoRoot, 'package.json'), 'utf8'),
+    ) as { version: string };
+
+    expect(APP_VERSION).toBe(rootPackage.version);
+  });
+});

--- a/libs/koala-nest/.vscode/tasks.json
+++ b/libs/koala-nest/.vscode/tasks.json
@@ -27,6 +27,15 @@
     },
     {
       "type": "shell",
+      "command": "bun run test:e2e",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "label": "Run E2E tests"
+    },
+    {
+      "type": "shell",
       "command": "bun run migration:run",
       "options": {
         "cwd": "${workspaceFolder}"

--- a/libs/koala-nest/src/application/common/request-validator.base.ts
+++ b/libs/koala-nest/src/application/common/request-validator.base.ts
@@ -6,7 +6,7 @@ export abstract class RequestValidatorBase<
   protected _request: Record<string, any>;
 
   constructor(request: TRequest) {
-    this._request = { ...request };
+    this._request = RequestValidatorBase.toValidationInput(request);
   }
 
   validate(): TRequest {
@@ -30,4 +30,39 @@ export abstract class RequestValidatorBase<
   }
 
   protected abstract get schema(): ZodType;
+
+  /**
+   * Objetos plain (query HTTP) passam direto. Instâncias de classe carregam
+   * defaults nos fields — removemos os que não foram alterados para o Zod
+   * aplicar defaults/transforms sem sobrescrever query params explícitos.
+   */
+  private static toValidationInput<T extends Record<string, unknown>>(
+    request: T,
+  ): Record<string, unknown> {
+    if (request === null || typeof request !== 'object') {
+      return {};
+    }
+
+    const prototype = Object.getPrototypeOf(request);
+    const isClassInstance =
+      prototype !== null &&
+      prototype !== Object.prototype &&
+      typeof prototype.constructor === 'function';
+
+    if (!isClassInstance) {
+      return { ...request };
+    }
+
+    const Constructor = prototype.constructor as new () => T;
+    const defaultValues = new Constructor() as Record<string, unknown>;
+    const input: Record<string, unknown> = { ...request };
+
+    for (const key of Object.keys(defaultValues)) {
+      if (Object.is(input[key], defaultValues[key])) {
+        delete input[key];
+      }
+    }
+
+    return input;
+  }
 }

--- a/libs/koala-nest/src/core/tools/mapping/auto-mapper.ts
+++ b/libs/koala-nest/src/core/tools/mapping/auto-mapper.ts
@@ -94,7 +94,11 @@ export class AutoMapper {
         continue;
       }
 
-      targetInstance[targetPropName] = data[sourceProp.name];
+      const sourceValue = data[sourceProp.name];
+
+      if (sourceValue !== undefined) {
+        targetInstance[targetPropName] = sourceValue;
+      }
     }
 
     return targetInstance;

--- a/libs/koala-nest/src/core/tools/mapping/mapping-store.ts
+++ b/libs/koala-nest/src/core/tools/mapping/mapping-store.ts
@@ -57,32 +57,40 @@ export class MappingStore {
         }
       }
 
-      current = Object.getPrototypeOf(current) as Type<any> | null;
+      const parentPrototype = Object.getPrototypeOf(current.prototype);
+      current = (parentPrototype?.constructor as Type<any> | undefined) ?? null;
     }
 
     return props;
   }
 
   static getPropType(entity: Type<any>, propName: string) {
-    const prop = this._entities.get(entity)?.find((p) => p.name === propName);
+    let current: Type<any> | null = entity;
 
-    if (!prop) {
-      throw new Error(
-        `Property ${propName} not found in entity ${entity.name}`,
-      );
+    while (current?.prototype) {
+      const prop = this._entities.get(current)?.find((p) => p.name === propName);
+
+      if (prop) {
+        const { type, isArray } = prop;
+
+        if (!type) {
+          return null;
+        }
+
+        if (isArray && type instanceof Function) {
+          return (type as () => Type<any>)();
+        }
+
+        return type;
+      }
+
+      const parentPrototype = Object.getPrototypeOf(current.prototype);
+      current = (parentPrototype?.constructor as Type<any> | undefined) ?? null;
     }
 
-    const { type, isArray } = prop;
-
-    if (!type) {
-      return null;
-    }
-
-    if (isArray && type instanceof Function) {
-      return (type as () => Type<any>)();
-    }
-
-    return type;
+    throw new Error(
+      `Property ${propName} not found in entity ${entity.name}`,
+    );
   }
 
   static add(

--- a/libs/koala-nest/src/test/application/read-many-person.handler.spec.ts
+++ b/libs/koala-nest/src/test/application/read-many-person.handler.spec.ts
@@ -21,16 +21,56 @@ describe('ReadManyPersonHandler', () => {
       contacts: [],
     });
 
+    let capturedPage: number | undefined;
     const repository = {
-      findMany: async () => ({ items: [person], count: 1 }),
+      findMany: async (query: { page?: number; skip: () => number }) => {
+        capturedPage = query.page;
+        return { items: [person], count: 1 };
+      },
     } as unknown as IPersonRepository;
 
     const handler = new ReadManyPersonHandler(repository, new CacheStub());
-    const result = await handler.handle(new ReadManyPersonRequest());
+    const result = await handler.handle({ page: '2', limit: '5' } as never);
 
+    expect(capturedPage).toBe(1);
     expect(result.count).toBe(1);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].name).toBe('Jane');
+  });
+
+  it('preserva paginação ao receber instância de ReadManyPersonRequest', async () => {
+    let capturedPage: number | undefined;
+    const repository = {
+      findMany: async (query: { page?: number }) => {
+        capturedPage = query.page;
+        return { items: [], count: 0 };
+      },
+    } as unknown as IPersonRepository;
+
+    const handler = new ReadManyPersonHandler(repository, new CacheStub());
+    const request = Object.assign(new ReadManyPersonRequest(), {
+      page: '2',
+      limit: '5',
+    });
+
+    await handler.handle(request);
+
+    expect(capturedPage).toBe(1);
+  });
+
+  it('aplica defaults de paginação quando a request não informa page', async () => {
+    let capturedPage: number | undefined;
+    const repository = {
+      findMany: async (query: { page?: number }) => {
+        capturedPage = query.page;
+        return { items: [], count: 0 };
+      },
+    } as unknown as IPersonRepository;
+
+    const handler = new ReadManyPersonHandler(repository, new CacheStub());
+    await handler.handle(new ReadManyPersonRequest());
+
+    expect(capturedPage).toBe(0);
   });
 
   it('reutiliza cache para a mesma consulta de listagem', async () => {

--- a/libs/koala-nest/src/test/core/mapping.spec.ts
+++ b/libs/koala-nest/src/test/core/mapping.spec.ts
@@ -137,6 +137,67 @@ describe('AutoMapper', () => {
     expect(target.fullName).toBe('John Doe');
   });
 
+  it('should map inherited properties from parent classes', () => {
+    class BaseRequest {
+      @AutoMap()
+      page?: number;
+
+      @AutoMap()
+      limit?: number;
+    }
+
+    class ChildRequest extends BaseRequest {
+      @AutoMap()
+      name?: string;
+    }
+
+    class BaseDto {
+      @AutoMap()
+      page?: number = 0;
+
+      @AutoMap()
+      limit?: number = 10;
+    }
+
+    class ChildDto extends BaseDto {
+      @AutoMap()
+      name?: string;
+    }
+
+    createMap(ChildRequest, ChildDto);
+
+    const source = Object.assign(new ChildRequest(), {
+      page: 2,
+      limit: 25,
+      name: 'John',
+    });
+
+    const target = AutoMapper.map(source, ChildRequest, ChildDto);
+
+    expect(target.page).toBe(2);
+    expect(target.limit).toBe(25);
+    expect(target.name).toBe('John');
+  });
+
+  it('should resolve inherited property types via getProps and getPropType', () => {
+    class BaseRequest {
+      @AutoMap()
+      page?: number;
+    }
+
+    class ChildRequest extends BaseRequest {
+      @AutoMap()
+      name?: string;
+    }
+
+    const props = MappingStore.getProps(ChildRequest).map((p) => p.name);
+
+    expect(props).toContain('page');
+    expect(props).toContain('name');
+    expect(MappingStore.getPropType(ChildRequest, 'page')).toBe(Number);
+    expect(MappingStore.getPropType(ChildRequest, 'name')).toBe(String);
+  });
+
   it('should map nested objects using the target property name', () => {
     class SourceChild {
       @AutoMap()

--- a/libs/koala-nest/src/test/host/controllers/app/app.e2e.spec.ts
+++ b/libs/koala-nest/src/test/host/controllers/app/app.e2e.spec.ts
@@ -1,0 +1,24 @@
+/// <reference types="bun-types/test-globals" />
+
+import { createE2ETestApp } from '@/test/create-e2e-test-app';
+import type { INestApplication } from '@nestjs/common';
+
+/**
+ * Estrutura mínima de E2E — use como ponto de partida no template Padrão.
+ * No exemplo CRUD, veja `person.controller.e2e.spec.ts` e `auth.controller.e2e.spec.ts`.
+ */
+describe('App (E2E)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await createE2ETestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should bootstrap the application', () => {
+    expect(app.getHttpServer()).toBeDefined();
+  });
+});

--- a/libs/koala-nest/src/test/utils/create-e2e-database.ts
+++ b/libs/koala-nest/src/test/utils/create-e2e-database.ts
@@ -10,7 +10,9 @@ function resolveMigrationRunner(): string {
     packageManager?: string;
   };
 
-  if (packageJson.packageManager === 'bun') {
+  const packageManager = packageJson.packageManager ?? 'bun';
+
+  if (packageManager === 'bun') {
     return 'bun';
   }
 

--- a/libs/koala-nest/src/test/utils/create-e2e-database.ts
+++ b/libs/koala-nest/src/test/utils/create-e2e-database.ts
@@ -1,8 +1,21 @@
 import { Type } from '@nestjs/common';
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { setE2EDatabaseUrl } from '../e2e-context';
 import { E2EDatabaseClient } from './e2e-database-client';
+
+function resolveMigrationRunner(): string {
+  const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+    packageManager?: string;
+  };
+
+  if (packageJson.packageManager === 'bun') {
+    return 'bun';
+  }
+
+  return 'node --import ts-node/register/transpile-only';
+}
 
 function generateUniqueDatabaseURL() {
   const schemaId = randomUUID();
@@ -33,8 +46,9 @@ export async function createE2EDatabase<T extends E2EDatabaseClient>(
     await client.createDatabase(schemaId);
 
     const env = { ...process.env, DATABASE_URL: url, NODE_ENV: 'test' };
+    const migrationRunner = resolveMigrationRunner();
     execSync(
-      'bun ./node_modules/typeorm/cli.js migration:run -d ./src/infra/database/migrations/migration-datasource.ts',
+      `${migrationRunner} ./node_modules/typeorm/cli.js migration:run -d ./src/infra/database/migrations/migration-datasource.ts`,
       {
         cwd: process.cwd(),
         env,

--- a/libs/koala-nest/vitest.config.e2e.ts
+++ b/libs/koala-nest/vitest.config.e2e.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    include: ['src/test/**/*.e2e.spec.ts'],
+    setupFiles: ['src/test/setup-e2e.ts'],
+    environment: 'node',
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/libs/koala-nest/vitest.config.ts
+++ b/libs/koala-nest/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    include: ['src/test/**/*.spec.ts'],
+    exclude: ['src/test/**/*.e2e.spec.ts'],
+    setupFiles: ['src/test/setup.ts'],
+    environment: 'node',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/nest",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "CLI para criar APIs NestJS com arquitetura DDD — copia módulos prontos para o seu repositório.",
   "license": "MIT",
   "type": "module",
@@ -20,7 +20,7 @@
     "build:koala-nest": "bun scripts/build-koala-nest.mjs",
     "build:cli": "bun scripts/build-cli.mjs",
     "build": "bun scripts/build.mjs",
-    "version": "git add -A libs",
+    "version": "bun run doc:manifest && git add -A libs",
     "postversion": "git push && git push --tags",
     "prepare:hotfix": "npm version patch",
     "prepare:feature": "npm version minor",

--- a/scripts/build-doc-manifest.mjs
+++ b/scripts/build-doc-manifest.mjs
@@ -14,6 +14,7 @@ import {
 const docRoot = path.resolve('libs/doc');
 const markdownRoot = path.join(docRoot, 'markdown');
 const manifestPath = path.join(docRoot, 'site/src/generated/docs-manifest.json');
+const appVersionPath = path.join(docRoot, 'site/src/app/core/constants/app-version.ts');
 const txtRoot = path.join(docRoot, 'txt');
 const publicRoot = path.join(docRoot, 'site/public');
 const publicMarkdownRoot = path.join(publicRoot, 'markdown');
@@ -146,6 +147,29 @@ function syncMarkdownToPublic() {
   return copied;
 }
 
+function syncAppVersion() {
+  const rootPackage = JSON.parse(
+    fs.readFileSync(path.resolve('package.json'), 'utf8'),
+  );
+  const version = rootPackage.version;
+
+  if (!version || typeof version !== 'string') {
+    throw new Error('package.json raiz precisa definir "version".');
+  }
+
+  fs.mkdirSync(path.dirname(appVersionPath), { recursive: true });
+  fs.writeFileSync(
+    appVersionPath,
+    [
+      '// Gerado por scripts/build-doc-manifest.mjs — não editar manualmente.',
+      `export const APP_VERSION = '${version}';`,
+      '',
+    ].join('\n'),
+  );
+
+  return version;
+}
+
 const locales = {};
 const routesByDocKey = {};
 
@@ -205,6 +229,7 @@ fs.mkdirSync(txtRoot, { recursive: true });
 fs.mkdirSync(publicRoot, { recursive: true });
 
 const markdownFiles = syncMarkdownToPublic();
+const appVersion = syncAppVersion();
 
 for (const locale of supportedLocales) {
   const llmsIndex = buildLlmsIndex(locales[locale].docs, locale);
@@ -217,4 +242,5 @@ for (const locale of supportedLocales) {
 
 const totalDocs = Object.values(locales).reduce((sum, l) => sum + l.docs.length, 0);
 console.log(`Manifest gerado: ${totalDocs} tópicos (${supportedLocales.join(', ')}) → ${manifestPath}`);
+console.log(`Versão da doc sincronizada: v${appVersion} → ${appVersionPath}`);
 console.log(`Markdown publicado: ${markdownFiles} arquivos → ${publicMarkdownRoot}`);


### PR DESCRIPTION
## Summary

Release única **4.0.6** consolidando:

- **feat:** infraestrutura `test:e2e` nos projetos gerados (Padrão + CRUD), task E2E no VS Code e header da doc sincronizado com a versão da CLI
- **fix:** runner Bun padrão de migrations no setup E2E (CI sem `packageManager`)
- **fix:** AutoMapper mapeia propriedades herdadas (`PaginationRequest` → DTO) e validator não sobrescreve query params com defaults de instância

## Test plan

- [x] `bun run test:unit`
- [x] Testes de mapping e `ReadManyPersonHandler` com paginação
- [ ] CI verde no PR
- [ ] Publicação npm `@koalarx/nest@4.0.6` após merge
- [ ] Deploy da documentação via GitHub Pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect code generation, request validation, and AutoMapper behavior used across handlers; E2E assumes local Postgres via `DATABASE_URL`.
> 
> **Overview**
> Release **4.0.6** wires **E2E testing into every `kl-nest new` project**: `configureE2ETestRunner` adds `test:e2e` (Bun with `setup-e2e` preload vs Vitest `vitest.config.e2e.ts`), keeps **supertest**, copies Vitest configs for npm/pnpm, updates VS Code tasks, and extends the CLI checklist so Default gets core E2E infra plus a minimal `app.e2e.spec.ts` while CRUD keeps Person/auth examples. The **Default** template now patches `AppTestModule` to `InfraModule` + ephemeral DB instead of stripping all E2E.
> 
> **Docs** document `test:e2e`; `build-doc-manifest.mjs` generates `APP_VERSION` from root `package.json` (with a unit test), `npm version` runs the manifest, and Pages deploy also triggers on `package.json` changes.
> 
> **Runtime fixes:** `RequestValidatorBase` drops unchanged class-field defaults so query pagination is not overwritten; **AutoMapper** / **MappingStore** walk inheritance for `@AutoMap` props and skip assigning `undefined` sources. E2E DB setup picks **bun vs node** for TypeORM migrations from `packageManager`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa29dbcd5e41e2f204e370a468c48416b6b3f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->