### PR TITLE
fix: corrige mapeamento de propriedades herdadas no AutoMapper

### DIFF
--- a/libs/koala-nest/src/application/common/request-validator.base.ts
+++ b/libs/koala-nest/src/application/common/request-validator.base.ts
@@ -6,7 +6,7 @@ export abstract class RequestValidatorBase<
   protected _request: Record<string, any>;
 
   constructor(request: TRequest) {
-    this._request = { ...request };
+    this._request = RequestValidatorBase.toValidationInput(request);
   }
 
   validate(): TRequest {
@@ -30,4 +30,39 @@ export abstract class RequestValidatorBase<
   }
 
   protected abstract get schema(): ZodType;
+
+  /**
+   * Objetos plain (query HTTP) passam direto. Instâncias de classe carregam
+   * defaults nos fields — removemos os que não foram alterados para o Zod
+   * aplicar defaults/transforms sem sobrescrever query params explícitos.
+   */
+  private static toValidationInput<T extends Record<string, unknown>>(
+    request: T,
+  ): Record<string, unknown> {
+    if (request === null || typeof request !== 'object') {
+      return {};
+    }
+
+    const prototype = Object.getPrototypeOf(request);
+    const isClassInstance =
+      prototype !== null &&
+      prototype !== Object.prototype &&
+      typeof prototype.constructor === 'function';
+
+    if (!isClassInstance) {
+      return { ...request };
+    }
+
+    const Constructor = prototype.constructor as new () => T;
+    const defaultValues = new Constructor() as Record<string, unknown>;
+    const input: Record<string, unknown> = { ...request };
+
+    for (const key of Object.keys(defaultValues)) {
+      if (Object.is(input[key], defaultValues[key])) {
+        delete input[key];
+      }
+    }
+
+    return input;
+  }
 }

--- a/libs/koala-nest/src/core/tools/mapping/auto-mapper.ts
+++ b/libs/koala-nest/src/core/tools/mapping/auto-mapper.ts
@@ -94,7 +94,11 @@ export class AutoMapper {
         continue;
       }
 
-      targetInstance[targetPropName] = data[sourceProp.name];
+      const sourceValue = data[sourceProp.name];
+
+      if (sourceValue !== undefined) {
+        targetInstance[targetPropName] = sourceValue;
+      }
     }
 
     return targetInstance;

--- a/libs/koala-nest/src/core/tools/mapping/mapping-store.ts
+++ b/libs/koala-nest/src/core/tools/mapping/mapping-store.ts
@@ -57,32 +57,40 @@ export class MappingStore {
         }
       }
 
-      current = Object.getPrototypeOf(current) as Type<any> | null;
+      const parentPrototype = Object.getPrototypeOf(current.prototype);
+      current = (parentPrototype?.constructor as Type<any> | undefined) ?? null;
     }
 
     return props;
   }
 
   static getPropType(entity: Type<any>, propName: string) {
-    const prop = this._entities.get(entity)?.find((p) => p.name === propName);
+    let current: Type<any> | null = entity;
 
-    if (!prop) {
-      throw new Error(
-        `Property ${propName} not found in entity ${entity.name}`,
-      );
+    while (current?.prototype) {
+      const prop = this._entities.get(current)?.find((p) => p.name === propName);
+
+      if (prop) {
+        const { type, isArray } = prop;
+
+        if (!type) {
+          return null;
+        }
+
+        if (isArray && type instanceof Function) {
+          return (type as () => Type<any>)();
+        }
+
+        return type;
+      }
+
+      const parentPrototype = Object.getPrototypeOf(current.prototype);
+      current = (parentPrototype?.constructor as Type<any> | undefined) ?? null;
     }
 
-    const { type, isArray } = prop;
-
-    if (!type) {
-      return null;
-    }
-
-    if (isArray && type instanceof Function) {
-      return (type as () => Type<any>)();
-    }
-
-    return type;
+    throw new Error(
+      `Property ${propName} not found in entity ${entity.name}`,
+    );
   }
 
   static add(

--- a/libs/koala-nest/src/test/application/read-many-person.handler.spec.ts
+++ b/libs/koala-nest/src/test/application/read-many-person.handler.spec.ts
@@ -21,16 +21,56 @@ describe('ReadManyPersonHandler', () => {
       contacts: [],
     });
 
+    let capturedPage: number | undefined;
     const repository = {
-      findMany: async () => ({ items: [person], count: 1 }),
+      findMany: async (query: { page?: number; skip: () => number }) => {
+        capturedPage = query.page;
+        return { items: [person], count: 1 };
+      },
     } as unknown as IPersonRepository;
 
     const handler = new ReadManyPersonHandler(repository, new CacheStub());
-    const result = await handler.handle(new ReadManyPersonRequest());
+    const result = await handler.handle({ page: '2', limit: '5' } as never);
 
+    expect(capturedPage).toBe(1);
     expect(result.count).toBe(1);
     expect(result.items).toHaveLength(1);
     expect(result.items[0].name).toBe('Jane');
+  });
+
+  it('preserva paginação ao receber instância de ReadManyPersonRequest', async () => {
+    let capturedPage: number | undefined;
+    const repository = {
+      findMany: async (query: { page?: number }) => {
+        capturedPage = query.page;
+        return { items: [], count: 0 };
+      },
+    } as unknown as IPersonRepository;
+
+    const handler = new ReadManyPersonHandler(repository, new CacheStub());
+    const request = Object.assign(new ReadManyPersonRequest(), {
+      page: '2',
+      limit: '5',
+    });
+
+    await handler.handle(request);
+
+    expect(capturedPage).toBe(1);
+  });
+
+  it('aplica defaults de paginação quando a request não informa page', async () => {
+    let capturedPage: number | undefined;
+    const repository = {
+      findMany: async (query: { page?: number }) => {
+        capturedPage = query.page;
+        return { items: [], count: 0 };
+      },
+    } as unknown as IPersonRepository;
+
+    const handler = new ReadManyPersonHandler(repository, new CacheStub());
+    await handler.handle(new ReadManyPersonRequest());
+
+    expect(capturedPage).toBe(0);
   });
 
   it('reutiliza cache para a mesma consulta de listagem', async () => {

--- a/libs/koala-nest/src/test/core/mapping.spec.ts
+++ b/libs/koala-nest/src/test/core/mapping.spec.ts
@@ -137,6 +137,67 @@ describe('AutoMapper', () => {
     expect(target.fullName).toBe('John Doe');
   });
 
+  it('should map inherited properties from parent classes', () => {
+    class BaseRequest {
+      @AutoMap()
+      page?: number;
+
+      @AutoMap()
+      limit?: number;
+    }
+
+    class ChildRequest extends BaseRequest {
+      @AutoMap()
+      name?: string;
+    }
+
+    class BaseDto {
+      @AutoMap()
+      page?: number = 0;
+
+      @AutoMap()
+      limit?: number = 10;
+    }
+
+    class ChildDto extends BaseDto {
+      @AutoMap()
+      name?: string;
+    }
+
+    createMap(ChildRequest, ChildDto);
+
+    const source = Object.assign(new ChildRequest(), {
+      page: 2,
+      limit: 25,
+      name: 'John',
+    });
+
+    const target = AutoMapper.map(source, ChildRequest, ChildDto);
+
+    expect(target.page).toBe(2);
+    expect(target.limit).toBe(25);
+    expect(target.name).toBe('John');
+  });
+
+  it('should resolve inherited property types via getProps and getPropType', () => {
+    class BaseRequest {
+      @AutoMap()
+      page?: number;
+    }
+
+    class ChildRequest extends BaseRequest {
+      @AutoMap()
+      name?: string;
+    }
+
+    const props = MappingStore.getProps(ChildRequest).map((p) => p.name);
+
+    expect(props).toContain('page');
+    expect(props).toContain('name');
+    expect(MappingStore.getPropType(ChildRequest, 'page')).toBe(Number);
+    expect(MappingStore.getPropType(ChildRequest, 'name')).toBe(String);
+  });
+
   it('should map nested objects using the target property name', () => {
     class SourceChild {
       @AutoMap()


### PR DESCRIPTION
## Summary

- Corrige `MappingStore.getProps` e `getPropType` para percorrer a cadeia de herança via `prototype` (ex.: `PaginationRequest` → `ReadManyPersonRequest`).
- Evita sobrescrever defaults do DTO com `undefined` no `AutoMapper`.
- Ajusta `RequestValidatorBase` para não tratar defaults de instância de classe como query params enviados, preservando paginação explícita na URL.

## Test plan

- [x] `bun test src/test/core/mapping.spec.ts`
- [x] `bun test src/test/application/read-many-person.handler.spec.ts`
- [x] `bun run test:unit`
- [ ] Validar manualmente `GET /person?page=2` → `query.page = 1` (0-based interno)


Made with [Cursor](https://cursor.com)