### PR TITLE
Oculta OnThisPage no mobile sem afetar scroll por âncora

### DIFF
--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.html
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.html
@@ -1,4 +1,4 @@
-<aside class="fixed hidden md:block w-64 right-4 top-20 text-xs pl-4">
+<aside class="fixed hidden lg:block w-64 right-4 top-20 text-xs pl-4">
   <h4 class="opacity-70">{{ copy().onThisPage }}</h4>
   <ul class="mt-4 space-y-1">
     @for (item of items(); track item.fragment) {

--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
@@ -21,6 +21,9 @@ interface TocItem {
   selector: 'app-doc-on-this-page',
   templateUrl: './doc-on-this-page.component.html',
   imports: [RouterLink],
+  host: {
+    class: 'contents',
+  },
 })
 export class DocOnThisPageComponent implements OnDestroy {
   private readonly localeService = inject(LocaleService);

--- a/libs/doc/site/src/app/features/doc/doc-page.component.html
+++ b/libs/doc/site/src/app/features/doc/doc-page.component.html
@@ -1,6 +1,6 @@
 @if (doc(); as page) {
   <section class="relative flex py-4">
-    <article #articleRef class="min-w-0 w-full md:w-[calc(100%-16rem)]">
+    <article #articleRef class="min-w-0 w-full lg:w-[calc(100%-16rem)]">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-6 gap-4">
         <div class="flex flex-col">
           <h1 class="text-4xl sm:text-5xl font-bold">{{ page.title }}</h1>


### PR DESCRIPTION
## Summary
- Alinha o breakpoint visual do índice "Nesta página" ao da sidebar (`lg`), evitando sobreposição do conteúdo em telas menores.
- Ajusta a largura do artigo para reservar espaço ao índice somente a partir de `lg`.
- Usa `host: { class: 'contents' }` para o componente não interferir no layout flex no mobile.

## Test plan
- [ ] Abrir uma página de documentação no mobile (<1024px) e confirmar que o OnThisPage não aparece.
- [ ] Abrir link com âncora (ex.: `#setup`) e confirmar que o scroll automático continua funcionando.
- [ ] Em viewport `lg+`, confirmar que o índice lateral continua visível e funcional.


Made with [Cursor](https://cursor.com)