### PR TITLE
Release: develop → main (OnThisPage mobile + melhorias recentes)

### DIFF
--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.html
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.html
@@ -1,4 +1,4 @@
-<aside class="fixed hidden md:block w-64 right-4 top-20 text-xs pl-4">
+<aside class="fixed hidden lg:block w-64 right-4 top-20 text-xs pl-4">
   <h4 class="opacity-70">{{ copy().onThisPage }}</h4>
   <ul class="mt-4 space-y-1">
     @for (item of items(); track item.fragment) {

--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
@@ -21,6 +21,9 @@ interface TocItem {
   selector: 'app-doc-on-this-page',
   templateUrl: './doc-on-this-page.component.html',
   imports: [RouterLink],
+  host: {
+    class: 'contents',
+  },
 })
 export class DocOnThisPageComponent implements OnDestroy {
   private readonly localeService = inject(LocaleService);

--- a/libs/doc/site/src/app/features/doc/doc-page.component.html
+++ b/libs/doc/site/src/app/features/doc/doc-page.component.html
@@ -1,6 +1,6 @@
 @if (doc(); as page) {
   <section class="relative flex py-4">
-    <article #articleRef class="min-w-0 w-full md:w-[calc(100%-16rem)]">
+    <article #articleRef class="min-w-0 w-full lg:w-[calc(100%-16rem)]">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-6 gap-4">
         <div class="flex flex-col">
           <h1 class="text-4xl sm:text-5xl font-bold">{{ page.title }}</h1>


### PR DESCRIPTION
## Summary
- Oculta o índice "Nesta página" abaixo de `lg` no site de documentação, evitando sobreposição no mobile sem afetar scroll por âncora.
- Inclui demais commits já integrados em `develop` desde o último merge em `main`.

## Test plan
- [ ] CI verde (CLI, koala-nest, docs unit/e2e).
- [ ] Após merge, confirmar deploy da documentação no GitHub Pages.
- [ ] Validar layout mobile da doc e links com âncora.


Made with [Cursor](https://cursor.com)