### PR TITLE
Corrige ocultação do OnThisPage em mobile e tablet

### DIFF
--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.html
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.html
@@ -1,20 +1,22 @@
-<aside class="fixed hidden lg:block w-64 right-4 top-20 text-xs pl-4">
-  <h4 class="opacity-70">{{ copy().onThisPage }}</h4>
-  <ul class="mt-4 space-y-1">
-    @for (item of items(); track item.fragment) {
-      @let isActive = activeSectionId() === item.fragment;
+@if (showNavigation()) {
+  <aside class="fixed w-64 right-4 top-20 text-xs pl-4">
+    <h4 class="opacity-70">{{ copy().onThisPage }}</h4>
+    <ul class="mt-4 space-y-1">
+      @for (item of items(); track item.fragment) {
+        @let isActive = activeSectionId() === item.fragment;
 
-      <a
-        class="opacity-70 hover:opacity-100 transition-opacity"
-        [class.opacity-100]="isActive"
-        [class.font-semibold]="isActive"
-        [routerLink]="[]"
-        [fragment]="item.fragment"
-      >
-        <li class="py-1">
-          {{ item.label }}
-        </li>
-      </a>
-    }
-  </ul>
-</aside>
+        <a
+          class="opacity-70 hover:opacity-100 transition-opacity"
+          [class.opacity-100]="isActive"
+          [class.font-semibold]="isActive"
+          [routerLink]="[]"
+          [fragment]="item.fragment"
+        >
+          <li class="py-1">
+            {{ item.label }}
+          </li>
+        </a>
+      }
+    </ul>
+  </aside>
+}

--- a/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
+++ b/libs/doc/site/src/app/core/components/doc-on-this-page/doc-on-this-page.component.ts
@@ -1,10 +1,13 @@
+import { isPlatformBrowser } from '@angular/common';
 import {
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   input,
   OnDestroy,
+  PLATFORM_ID,
   signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -17,26 +20,43 @@ interface TocItem {
   fragment: string;
 }
 
+const DESKTOP_TOC_MIN_WIDTH = 1280;
+
 @Component({
   selector: 'app-doc-on-this-page',
   templateUrl: './doc-on-this-page.component.html',
   imports: [RouterLink],
-  host: {
-    class: 'contents',
-  },
 })
 export class DocOnThisPageComponent implements OnDestroy {
   private readonly localeService = inject(LocaleService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private observer?: IntersectionObserver;
+  private mediaQuery?: MediaQueryList;
+  private readonly onViewportChange = () => {
+    if (this.mediaQuery) {
+      this.showNavigation.set(this.mediaQuery.matches);
+    }
+  };
 
   readonly contentRoot = input<HTMLElement | null>(null);
   readonly refreshToken = input(0);
 
   readonly items = signal<TocItem[]>([]);
   readonly activeSectionId = signal('');
+  readonly showNavigation = signal(false);
   readonly copy = computed(() => UI_COPY[this.localeService.locale()]);
 
   constructor() {
+    if (this.isBrowser) {
+      this.mediaQuery = window.matchMedia(`(min-width: ${DESKTOP_TOC_MIN_WIDTH}px)`);
+      this.onViewportChange();
+      this.mediaQuery.addEventListener('change', this.onViewportChange);
+      this.destroyRef.onDestroy(() => {
+        this.mediaQuery?.removeEventListener('change', this.onViewportChange);
+      });
+    }
+
     effect(() => {
       const root = this.contentRoot();
       const token = this.refreshToken();

--- a/libs/doc/site/src/app/features/doc/doc-page.component.html
+++ b/libs/doc/site/src/app/features/doc/doc-page.component.html
@@ -1,6 +1,6 @@
 @if (doc(); as page) {
   <section class="relative flex py-4">
-    <article #articleRef class="min-w-0 w-full lg:w-[calc(100%-16rem)]">
+    <article #articleRef class="min-w-0 w-full xl:w-[calc(100%-16rem)]">
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between mb-6 gap-4">
         <div class="flex flex-col">
           <h1 class="text-4xl sm:text-5xl font-bold">{{ page.title }}</h1>

--- a/libs/doc/site/src/app/site.e2e.spec.ts
+++ b/libs/doc/site/src/app/site.e2e.spec.ts
@@ -22,6 +22,31 @@ test('abre página de documentação em inglês', async ({ page }) => {
   await expect(page.locator('h1')).toContainText(/installation/i);
 });
 
+test('oculta OnThisPage em viewport mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/pt/docs/inicio/guia-de-instalacao');
+  await expect(page.locator('app-doc-on-this-page aside')).toHaveCount(0);
+});
+
+test('oculta OnThisPage em viewport tablet (1024px)', async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await page.goto('/pt/docs/inicio/guia-de-instalacao');
+  await expect(page.locator('app-doc-on-this-page aside')).toHaveCount(0);
+});
+
+test('exibe OnThisPage em desktop largo', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/pt/docs/inicio/guia-de-instalacao');
+  await expect(page.locator('app-doc-on-this-page aside')).toBeVisible();
+  await expect(page.getByText('Nesta página', { exact: true })).toBeVisible();
+});
+
+test('scroll por âncora funciona no mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/pt/docs/inicio/guia-de-instalacao#forma-rapida-usando-a-cli');
+  await expect(page.locator('#forma-rapida-usando-a-cli')).toBeInViewport();
+});
+
 test('expõe llms.txt e markdown estático', async ({ request }) => {
   const llms = await request.get('/llms.txt');
   expect(llms.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary
- Renderiza o índice "Nesta página" somente a partir de 1280px via `matchMedia`, removendo o aside do DOM em mobile/tablet (inclui iPad em 1024px).
- Ajusta a largura reservada do artigo para o breakpoint `xl`.
- Adiciona testes e2e de visibilidade do OnThisPage e scroll por âncora no mobile.

## Test plan
- [x] `bun run test:docs:e2e` local (9/9)
- [ ] Validar no iPad/tablet que o índice lateral não aparece
- [ ] Confirmar links `#âncora` no mobile


Made with [Cursor](https://cursor.com)