### PR TITLE
Corrige sidebar no mobile e escopa testes da CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,11 +2,47 @@ name: PR TESTS
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      cli: ${{ steps.filter.outputs.cli }}
+      koala-nest: ${{ steps.filter.outputs.koala-nest }}
+      docs: ${{ steps.filter.outputs.docs }}
+      shared: ${{ steps.filter.outputs.shared }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cli:
+              - 'libs/cli/**'
+              - 'scripts/build-cli.mjs'
+            koala-nest:
+              - 'libs/koala-nest/**'
+              - 'scripts/build-koala-nest.mjs'
+            docs:
+              - 'libs/doc/**'
+              - 'scripts/build-doc-manifest.mjs'
+              - 'scripts/migrate-en-doc-slugs.mjs'
+            shared:
+              - 'package.json'
+              - 'bun.lock'
+              - 'scripts/build.mjs'
+              - 'scripts/deprecate-legacy-packages.mjs'
+              - '.github/workflows/pr-tests.yml'
+
   cli-unit-tests:
     name: CLI Unit Tests
+    needs: changes
+    if: needs.changes.outputs.cli == 'true' || needs.changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -24,6 +60,8 @@ jobs:
 
   koala-nest-unit-tests:
     name: Koala Nest Unit Tests
+    needs: changes
+    if: needs.changes.outputs.koala-nest == 'true' || needs.changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -43,6 +81,8 @@ jobs:
 
   koala-nest-e2e-tests:
     name: Koala Nest E2E Tests
+    needs: changes
+    if: needs.changes.outputs.koala-nest == 'true' || needs.changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
 
     services:
@@ -81,6 +121,11 @@ jobs:
 
   cli-e2e-tests:
     name: CLI E2E Tests
+    needs: changes
+    if: >-
+      needs.changes.outputs.cli == 'true' ||
+      needs.changes.outputs.koala-nest == 'true' ||
+      needs.changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -105,6 +150,8 @@ jobs:
 
   docs-tests:
     name: Docs Site Tests
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/libs/doc/site/src/app/app.html
+++ b/libs/doc/site/src/app/app.html
@@ -5,7 +5,9 @@
 
   <div class="flex w-full">
     @if (isDocPage()) {
-      <app-docs-sidebar class="fixed hidden lg:block left-5 lg:left-15 top-16 z-[5]" />
+      <div class="fixed hidden lg:block left-5 lg:left-15 top-16 z-[5] w-60 h-[calc(100vh-4rem)]">
+        <app-docs-sidebar class="block h-full" />
+      </div>
     }
 
     <section [class]="mainSectionClass()">

--- a/libs/doc/site/src/app/core/components/docs-sidebar/docs-sidebar.component.css
+++ b/libs/doc/site/src/app/core/components/docs-sidebar/docs-sidebar.component.css
@@ -1,5 +1,4 @@
 :host {
-  display: block;
   width: 100%;
   min-height: 0;
   flex: 1 1 auto;

--- a/libs/doc/site/src/app/core/components/site-header/site-header.component.html
+++ b/libs/doc/site/src/app/core/components/site-header/site-header.component.html
@@ -88,8 +88,9 @@
 }
 
 <aside
-  class="fixed left-0 top-0 z-40 h-full w-72 max-w-[85vw] bg-base-100 border-r border-base-300 shadow-xl transition-transform duration-200 ease-out lg:hidden flex flex-col"
+  class="fixed left-0 top-0 z-40 h-full w-72 max-w-[85vw] bg-base-100 border-r border-base-300 shadow-xl transition-transform duration-200 ease-out lg:hidden flex flex-col pointer-events-none"
   [class.translate-x-0]="mobileMenuOpen()"
+  [class.pointer-events-auto]="mobileMenuOpen()"
   [class.-translate-x-full]="!mobileMenuOpen()"
 >
   <div class="px-4 py-4 border-b border-base-300 flex items-center justify-between gap-3 shrink-0">

--- a/libs/doc/site/src/app/site.e2e.spec.ts
+++ b/libs/doc/site/src/app/site.e2e.spec.ts
@@ -22,6 +22,13 @@ test('abre página de documentação em inglês', async ({ page }) => {
   await expect(page.locator('h1')).toContainText(/installation/i);
 });
 
+test('oculta sidebar desktop em viewport mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/pt/docs/inicio/guia-de-instalacao');
+  await expect(page.locator('div.fixed.hidden.lg\\:block')).toBeHidden();
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+});
+
 test('oculta OnThisPage em viewport mobile', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/pt/docs/inicio/guia-de-instalacao');


### PR DESCRIPTION
## Summary
- Remove `display: block` do `:host` da sidebar que anulava `hidden lg:block` e fazia o menu desktop sobrepor o conteúdo no mobile.
- Isola a sidebar desktop em um wrapper com `hidden lg:block`.
- Desabilita `pointer-events` do drawer mobile quando fechado.
- Publica pipeline com `dorny/paths-filter` para rodar testes apenas nos pacotes alterados.

## Test plan
- [x] `bun run test:docs:e2e` (10/10)
- [ ] PR com alteração só em `libs/doc/**` deve executar apenas Docs Site Tests
- [ ] Validar mobile em nest.koalarx.com


Made with [Cursor](https://cursor.com)