### PR TITLE
Corrige navegação do menu mobile

### DIFF
--- a/libs/doc/site/src/app/core/components/docs-sidebar/docs-sidebar.component.html
+++ b/libs/doc/site/src/app/core/components/docs-sidebar/docs-sidebar.component.html
@@ -10,7 +10,6 @@
                 class="block w-full rounded-lg px-3 py-2 text-sm opacity-60 hover:opacity-100 leading-snug"
                 [routerLink]="item.route"
                 routerLinkActive="opacity-100 bg-base-200"
-                (click)="onNavigate()"
               >
                 {{ item.title }}
               </a>

--- a/libs/doc/site/src/app/core/components/docs-sidebar/docs-sidebar.component.ts
+++ b/libs/doc/site/src/app/core/components/docs-sidebar/docs-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, output } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { DocsService } from '../../services/docs.service';
 
@@ -11,9 +11,4 @@ import { DocsService } from '../../services/docs.service';
 export class DocsSidebarComponent {
   private readonly docsService = inject(DocsService);
   readonly navigation = this.docsService.navigation;
-  readonly navigate = output<void>();
-
-  onNavigate() {
-    this.navigate.emit();
-  }
 }

--- a/libs/doc/site/src/app/core/components/site-header/site-header.component.html
+++ b/libs/doc/site/src/app/core/components/site-header/site-header.component.html
@@ -1,5 +1,5 @@
 <ng-template #logotype>
-  <a [routerLink]="homeLink()" (click)="closeMobileMenu()">
+  <a [routerLink]="homeLink()">
     <span class="flex items-center gap-3 mr-6">
       <i class="app-icon kl-logotype size-6!"></i>
       <span class="badge badge-sm badge-soft bg-neutral-800 font-semibold sm:inline-flex">
@@ -18,7 +18,6 @@
     [routerLink]="homeLink()"
     routerLinkActive="opacity-100"
     [routerLinkActiveOptions]="{ exact: true }"
-    (click)="closeMobileMenu()"
   >
     {{ copy().home }}
   </a>
@@ -31,7 +30,6 @@
     [routerLink]="docsNavLink()"
     routerLinkActive="opacity-100"
     [routerLinkActiveOptions]="{ exact: false }"
-    (click)="closeMobileMenu()"
   >
     {{ copy().docs }}
   </a>
@@ -78,7 +76,8 @@
 
 @if (mobileMenuVisible()) {
   <button
-    class="fixed inset-0 z-30 bg-black/40 transition-opacity duration-200 ease-out lg:hidden"
+    class="fixed inset-y-0 right-0 z-40 bg-black/40 transition-opacity duration-200 ease-out lg:hidden pointer-events-auto"
+    [style.left]="'min(85vw, 18rem)'"
     [class.opacity-100]="mobileMenuOpen()"
     [class.opacity-0]="!mobileMenuOpen()"
     (click)="closeMobileMenu()"
@@ -88,16 +87,15 @@
 }
 
 <aside
-  class="fixed left-0 top-0 z-40 h-full w-72 max-w-[85vw] bg-base-100 border-r border-base-300 shadow-xl transition-transform duration-200 ease-out lg:hidden flex flex-col pointer-events-none"
+  class="fixed left-0 top-0 z-50 h-full w-72 max-w-[85vw] bg-base-100 border-r border-base-300 shadow-xl transition-transform duration-200 ease-out lg:hidden flex flex-col"
   [class.translate-x-0]="mobileMenuOpen()"
-  [class.pointer-events-auto]="mobileMenuOpen()"
   [class.-translate-x-full]="!mobileMenuOpen()"
 >
   <div class="px-4 py-4 border-b border-base-300 flex items-center justify-between gap-3 shrink-0">
     <ng-container *ngTemplateOutlet="logotype" />
   </div>
 
-  <app-docs-sidebar class="block flex-1 min-h-0" (navigate)="closeMobileMenu()" />
+  <app-docs-sidebar class="block flex-1 min-h-0" />
 
   <div class="px-3 py-3 border-t border-base-300 shrink-0">
     <div class="grid grid-cols-1 gap-2">
@@ -114,7 +112,7 @@
           [class.bg-base-200]="locale() === 'pt'"
           [class.opacity-100]="locale() === 'pt'"
           [class.opacity-50]="locale() !== 'pt'"
-          (click)="switchLocale('pt'); closeMobileMenu()"
+          (click)="switchLocale('pt')"
         >
           PT
         </button>
@@ -124,7 +122,7 @@
           [class.bg-base-200]="locale() === 'en'"
           [class.opacity-100]="locale() === 'en'"
           [class.opacity-50]="locale() !== 'en'"
-          (click)="switchLocale('en'); closeMobileMenu()"
+          (click)="switchLocale('en')"
         >
           EN
         </button>

--- a/libs/doc/site/src/app/core/components/site-header/site-header.component.ts
+++ b/libs/doc/site/src/app/core/components/site-header/site-header.component.ts
@@ -1,6 +1,8 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, computed, inject, signal } from '@angular/core';
-import { Router, RouterLink, RouterLinkActive } from '@angular/router';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive } from '@angular/router';
+import { filter } from 'rxjs';
 import { Button } from '@/shared/components/button';
 import { APP_VERSION } from '../../constants/app-version';
 import { UI_COPY } from '../../i18n/ui-copy';
@@ -28,6 +30,7 @@ export class SiteHeaderComponent {
   private readonly searchService = inject(SearchService);
   private readonly localeService = inject(LocaleService);
   private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly version = `v${APP_VERSION}`;
   readonly mobileMenuVisible = signal(false);
@@ -40,6 +43,19 @@ export class SiteHeaderComponent {
   readonly docsNavLink = computed(() => this.localeService.docsRootRoute());
   readonly llmsUrl = () => absoluteSiteUrl(this.localeService.llmsFile());
 
+  constructor() {
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        if (this.mobileMenuVisible()) {
+          this.closeMobileMenu();
+        }
+      });
+  }
+
   switchLocale(target: 'pt' | 'en') {
     if (target === this.localeService.locale()) return;
     void this.router.navigateByUrl(this.localeService.switchLocalePath(target));
@@ -47,12 +63,13 @@ export class SiteHeaderComponent {
 
   toggleMobileMenu() {
     const visible = this.mobileMenuVisible();
-    this.mobileMenuVisible.set(!visible);
     if (!visible) {
-      setTimeout(() => this.mobileMenuOpen.set(true), 10);
-    } else {
-      this.closeMobileMenu();
+      this.mobileMenuVisible.set(true);
+      this.mobileMenuOpen.set(true);
+      return;
     }
+
+    this.closeMobileMenu();
   }
 
   closeMobileMenu() {

--- a/libs/doc/site/src/app/site.e2e.spec.ts
+++ b/libs/doc/site/src/app/site.e2e.spec.ts
@@ -22,6 +22,14 @@ test('abre página de documentação em inglês', async ({ page }) => {
   await expect(page.locator('h1')).toContainText(/installation/i);
 });
 
+test('menu mobile navega para outra página de documentação', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/pt/docs/inicio/guia-de-instalacao');
+  await page.getByRole('button', { name: 'Abrir menu' }).click();
+  await page.locator('app-site-header aside app-docs-sidebar a').filter({ hasText: 'Visão geral' }).click();
+  await expect(page).toHaveURL(/\/pt\/docs\/intro\/visao-geral$/);
+});
+
 test('oculta sidebar desktop em viewport mobile', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/pt/docs/inicio/guia-de-instalacao');


### PR DESCRIPTION
## Summary
- Backdrop passa a cobrir só a área fora do drawer (não intercepta cliques nos links).
- Menu abre de forma síncrona, sem janela com `pointer-events-none`.
- Drawer fecha após `NavigationEnd`, sem cancelar o `RouterLink`.

## Test plan
- [x] e2e: menu mobile navega para outra página de doc
- [ ] Validar no celular: abrir menu → tocar item → mudar de página


Made with [Cursor](https://cursor.com)