### PR TITLE
Endurece template com middleware HTTP, lazy loading e remoção de legado

### DIFF
--- a/libs/cli/constants/cli-project-checklist.ts
+++ b/libs/cli/constants/cli-project-checklist.ts
@@ -49,6 +49,11 @@ export const WORKSPACE_SETUP_PATHS = [
 /** Núcleo comum a qualquer projeto Koala Nest. */
 export const CORE_REQUIRED_PATHS = [
   'src/core/env.ts',
+  'src/core/common/list-response.base.ts',
+  'src/core/utils/initialize-undefined-array-props.ts',
+  'src/core/http/rate-limit.middleware.ts',
+  'src/core/utils/resolve-cors-origins.ts',
+  'src/host/bootstrap/apply-http-middleware.ts',
   'src/host/main.ts',
   'src/host/app.module.ts',
   'src/host/jobs/jobs.module.ts',

--- a/libs/cli/constants/core-packages.ts
+++ b/libs/cli/constants/core-packages.ts
@@ -9,7 +9,10 @@ export const CORE_PACKAGES = [
   'pg',
   'zod',
   '@scalar/nestjs-api-reference',
+  'cookie-parser',
 ] as const;
+
+export const CORE_DEV_PACKAGES = ['@types/cookie-parser'] as const;
 
 /** Redis — instalado ao selecionar Cache (Redis). */
 export const CACHE_PACKAGES = ['ioredis'] as const;
@@ -20,14 +23,10 @@ export const AUTH_PACKAGES = [
   '@nestjs/passport',
   'passport',
   'passport-jwt',
-  'cookie-parser',
   'bcrypt',
 ] as const;
 
-export const AUTH_DEV_PACKAGES = [
-  '@types/cookie-parser',
-  '@types/bcrypt',
-] as const;
+export const AUTH_DEV_PACKAGES = ['@types/bcrypt'] as const;
 
 /** Jobs internos com expressão cron. */
 export const CRON_PACKAGES = ['cron-parser'] as const;

--- a/libs/cli/test/unit/add-command.spec.ts
+++ b/libs/cli/test/unit/add-command.spec.ts
@@ -135,6 +135,10 @@ describe('parseAddArgs', () => {
     ]);
   });
 
+  it('rejeita rate-limit como feature desconhecida', () => {
+    expect(() => parseAddArgs(['rate-limit'])).toThrow(/desconhecida/);
+  });
+
   it('aceita auth com estratégia', () => {
     expect(parseAddArgs(['auth', 'oauth2', 'cache'])).toEqual([
       { kind: 'auth', strategies: ['oauth2'] },

--- a/libs/cli/test/unit/core-packages.spec.ts
+++ b/libs/cli/test/unit/core-packages.spec.ts
@@ -6,6 +6,7 @@ import {
   AUTH_DEV_PACKAGES,
   AUTH_PACKAGES,
   CACHE_PACKAGES,
+  CORE_DEV_PACKAGES,
   CORE_PACKAGES,
   CRON_PACKAGES,
   HEALTH_PACKAGES,
@@ -22,7 +23,7 @@ describe('core-packages', () => {
   it('instala apenas dependências essenciais no core', () => {
     expect(CORE_PACKAGES).toContain('@koalarx/utils');
     expect(CORE_PACKAGES).toContain('@scalar/nestjs-api-reference');
-    expect(CORE_PACKAGES).not.toContain('cookie-parser');
+    expect(CORE_PACKAGES).toContain('cookie-parser');
     expect(CORE_PACKAGES).not.toContain('cron-parser');
     expect(CORE_PACKAGES).not.toContain('ioredis');
     expect(CORE_PACKAGES).not.toContain('@nestjs/terminus');
@@ -31,11 +32,12 @@ describe('core-packages', () => {
 
   it('agrupa pacotes por feature', () => {
     expect(AUTH_PACKAGES).toContain('@nestjs/jwt');
-    expect(AUTH_PACKAGES).toContain('cookie-parser');
+    expect(AUTH_PACKAGES).not.toContain('cookie-parser');
     expect(CACHE_PACKAGES).toEqual(['ioredis']);
     expect(CRON_PACKAGES).toEqual(['cron-parser']);
     expect(HEALTH_PACKAGES).toEqual(['@nestjs/terminus', '@nestjs/axios']);
-    expect(AUTH_DEV_PACKAGES).toContain('@types/cookie-parser');
+    expect(CORE_DEV_PACKAGES).toContain('@types/cookie-parser');
+    expect(AUTH_DEV_PACKAGES).not.toContain('@types/cookie-parser');
   });
 
   it('usa flag de dev dependency por gerenciador', () => {

--- a/libs/cli/test/unit/parse-new-args.spec.ts
+++ b/libs/cli/test/unit/parse-new-args.spec.ts
@@ -106,6 +106,12 @@ describe('parseNewArgs', () => {
     ).toThrow(/CRUD exige autenticação/);
   });
 
+  it('rejeita rate-limit em --features', () => {
+    expect(() =>
+      parseNewArgs(['demo', '-y', '--features', 'cache,rate-limit']),
+    ).toThrow(/Feature desconhecida/);
+  });
+
   it('rejeita opção desconhecida', () => {
     expect(() => parseNewArgs(['demo', '--unknown'])).toThrow(/desconhecida/);
   });

--- a/libs/cli/test/unit/patch-main.spec.ts
+++ b/libs/cli/test/unit/patch-main.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { patchMainForAuth } from '@cli/utils/patch-main';
+
+const fullMain = `import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
+import { AppModule } from './app.module';
+import { defineDocumentation } from './open-api/define-documentation';
+import { ErrorsFilter } from './filters/errors.filter';
+import { HttpAdapterHost } from '@nestjs/core';
+import { ILoggingService } from '@/domain/common/ilogging.service';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  app.use(cookieParser());
+
+  app.enableCors({
+    credentials: true,
+    origin: true,
+    optionsSuccessStatus: 200,
+  });
+
+  await defineDocumentation(app);
+
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  const loggingService = app.get(ILoggingService);
+  app.useGlobalFilters(new ErrorsFilter(httpAdapter, loggingService));
+
+  await app.listen(process.env.PORT || 3000);
+}
+
+bootstrap();
+`;
+
+describe('patchMainForAuth', () => {
+  it('adiciona cookie parser quando main ainda não usa applyHttpMiddleware', () => {
+    const patched = patchMainForAuth(fullMain);
+
+    expect(patched).toContain('cookieParser()');
+  });
+
+  it('não altera main que já usa applyHttpMiddleware', () => {
+    const withMiddleware =
+      "import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';\napplyHttpMiddleware(app);";
+
+    expect(patchMainForAuth(withMiddleware)).toBe(withMiddleware);
+  });
+});

--- a/libs/cli/test/unit/patch-project-features.spec.ts
+++ b/libs/cli/test/unit/patch-project-features.spec.ts
@@ -5,10 +5,7 @@ import {
   SLIM_INFRA_MODULE,
   stripInfraModuleCache,
 } from '@cli/utils/patch-infra-module.ts';
-import {
-  patchMainForAuth,
-  stripMainOptionalFeatures,
-} from '@cli/utils/patch-main.ts';
+import { patchMainForAuth } from '@cli/utils/patch-main.ts';
 
 const fullMain = `import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
@@ -42,15 +39,8 @@ bootstrap();
 `;
 
 describe('patch-main', () => {
-  it('remove cookie parser do template completo', () => {
-    const stripped = stripMainOptionalFeatures(fullMain);
-
-    expect(stripped).not.toContain('cookieParser');
-  });
-
-  it('adiciona cookie parser para autenticação', () => {
-    const slim = stripMainOptionalFeatures(fullMain);
-    const patched = patchMainForAuth(slim);
+  it('adiciona cookie parser para autenticação em main legado', () => {
+    const patched = patchMainForAuth(fullMain);
 
     expect(patched).toContain('cookieParser()');
   });

--- a/libs/cli/utils/install-module.ts
+++ b/libs/cli/utils/install-module.ts
@@ -11,6 +11,7 @@ import {
   AUTH_DEV_PACKAGES,
   AUTH_PACKAGES,
   CACHE_PACKAGES,
+  CORE_DEV_PACKAGES,
   CORE_PACKAGES,
   CRON_PACKAGES,
   devAddFlag,
@@ -342,7 +343,7 @@ export async function installModule(
       patchInfraModuleFile(projectName, false);
 
       if (!options.skipPackages) {
-        await installPackages(projectName, CORE_PACKAGES);
+        await installPackages(projectName, CORE_PACKAGES, CORE_DEV_PACKAGES);
       }
 
       if (template === Template.DEFAULT) {

--- a/libs/cli/utils/install-module.ts
+++ b/libs/cli/utils/install-module.ts
@@ -34,7 +34,9 @@ import {
   stripInfraModuleCache,
 } from './patch-infra-module';
 import { patchAuthInstall } from './patch-auth-install';
-import { patchMainForAuth, stripMainOptionalFeatures } from './patch-main';
+import {
+  patchMainForAuth,
+} from './patch-main';
 import { restoreDefineDocumentationWithAuth } from './patch-define-documentation';
 import { pruneCoreAuthForSlimTemplate } from './prune-core-auth';
 import { removeSampleParts } from './remove-sample-parts';
@@ -240,6 +242,11 @@ export async function installModule(
       install('src/infra/repositories/repository.base.ts', projectName);
       install('src/infra/repositories/repository.module.ts', projectName);
       install('src/infra/infra.module.ts', projectName);
+      install('src/core/http/rate-limit.middleware.ts', projectName);
+      install('src/core/utils/resolve-cors-origins.ts', projectName);
+      install('src/host/bootstrap/apply-http-middleware.ts', projectName);
+      install('src/test/core/http/rate-limit.middleware.spec.ts', projectName);
+      install('src/test/core/resolve-cors-origins.spec.ts', projectName);
       install('src/test', projectName);
 
       rmSync(
@@ -270,10 +277,6 @@ export async function installModule(
         ),
         { force: true },
       );
-      rmSync(path.join(resolveProjectPath(projectName), 'src/host/bootstrap'), {
-        recursive: true,
-        force: true,
-      });
       rmSync(
         path.join(
           resolveProjectPath(projectName),
@@ -337,7 +340,6 @@ export async function installModule(
       }
 
       patchInfraModuleFile(projectName, false);
-      patchMainFile(projectName, stripMainOptionalFeatures);
 
       if (!options.skipPackages) {
         await installPackages(projectName, CORE_PACKAGES);

--- a/libs/cli/utils/parse-new-args.ts
+++ b/libs/cli/utils/parse-new-args.ts
@@ -1,9 +1,9 @@
 import type { PackageManager } from '@cli/types/index.ts';
 import {
-  AuthStrategy,
+  type AuthStrategy,
+  type ExtraFeature,
   FEATURE_ALIASES,
   parseAuthStrategies,
-  type ExtraFeature,
   Template,
   TEMPLATE_ALIASES,
 } from '@cli/constants/domain';

--- a/libs/cli/utils/patch-env.ts
+++ b/libs/cli/utils/patch-env.ts
@@ -9,12 +9,17 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
+  HOST: z.string().default('0.0.0.0'),
   NODE_ENV: z.enum(['test', 'develop', 'staging', 'production']),
   DATABASE_URL: z.string(),
   REDIS_CONNECTION_STRING: z.string().optional(),
   CACHE_KEY_PREFIX: z.string().optional(),
   CRON_JOBS_ENABLED: envBooleanSchema(false),
   BOOTSTRAP_DELAY_MS: z.coerce.number().default(0),
+  RATE_LIMIT_MAX: z.coerce.number().default(0),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60_000),
+  CORS_ORIGINS: z.string().optional(),
+  BCRYPT_ROUNDS: z.coerce.number().min(4).max(15).default(10),
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -25,6 +30,8 @@ export function validateEnvConfig(config: Record<string, unknown>): Env {
 `;
 
 const envExampleWithoutAuth = `PORT=3000
+# Endereço de bind do servidor (Docker/K8s). URLs públicas usam API_HOST.
+HOST=0.0.0.0
 NODE_ENV=develop
 DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 
@@ -37,6 +44,16 @@ DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 # Cron jobs internos. Ative com \`kl-nest add cron\`.
 CRON_JOBS_ENABLED=false
 BOOTSTRAP_DELAY_MS=0
+
+# Rate limit (0 = desabilitado)
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+
+# CORS — aberto por padrão; restrinja com origens separadas por vírgula se necessário
+# CORS_ORIGINS=http://localhost:4200,https://app.example.com
+
+# Custo do bcrypt (padrão 10)
+# BCRYPT_ROUNDS=10
 `;
 
 export function stripEnvAuth(projectName: string) {
@@ -64,12 +81,17 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
+  HOST: z.string().default('0.0.0.0'),
   NODE_ENV: z.enum(['test', 'develop', 'staging', 'production']),
   DATABASE_URL: z.string(),
   REDIS_CONNECTION_STRING: z.string().optional(),
   CACHE_KEY_PREFIX: z.string().optional(),
   CRON_JOBS_ENABLED: envBooleanSchema(false),
   BOOTSTRAP_DELAY_MS: z.coerce.number().default(0),
+  RATE_LIMIT_MAX: z.coerce.number().default(0),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60_000),
+  CORS_ORIGINS: z.string().optional(),
+  BCRYPT_ROUNDS: z.coerce.number().min(4).max(15).default(10),
   JWT_PRIVATE_KEY: z.string().optional(),
   JWT_PUBLIC_KEY: z.string().optional(),
   JWT_ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),
@@ -85,6 +107,8 @@ export function validateEnvConfig(config: Record<string, unknown>): Env {
 `;
 
 const envExampleJwtOnly = `PORT=3000
+# Endereço de bind do servidor (Docker/K8s). URLs públicas usam API_HOST.
+HOST=0.0.0.0
 NODE_ENV=develop
 DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 
@@ -94,6 +118,16 @@ DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 
 CRON_JOBS_ENABLED=false
 BOOTSTRAP_DELAY_MS=0
+
+# Rate limit (0 = desabilitado)
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+
+# CORS — aberto por padrão; restrinja com origens separadas por vírgula se necessário
+# CORS_ORIGINS=http://localhost:4200,https://app.example.com
+
+# Custo do bcrypt (padrão 10)
+# BCRYPT_ROUNDS=10
 
 # JWT (RS256 — chaves em base64)
 JWT_PRIVATE_KEY=

--- a/libs/cli/utils/patch-main.ts
+++ b/libs/cli/utils/patch-main.ts
@@ -1,10 +1,8 @@
-export function stripMainOptionalFeatures(content: string) {
-  return content
-    .replace(/import cookieParser from 'cookie-parser';\n/, '')
-    .replace(/\n {2}app\.use\(cookieParser\(\)\);\n/, '\n');
-}
-
 export function patchMainForAuth(content: string) {
+  if (content.includes('applyHttpMiddleware')) {
+    return content;
+  }
+
   if (content.includes('cookieParser()')) {
     return content;
   }

--- a/libs/cli/utils/remove-sample-parts.ts
+++ b/libs/cli/utils/remove-sample-parts.ts
@@ -4,7 +4,6 @@ import { removeImportLines } from './project-files';
 import { patchAppModuleJobs } from './patch-jobs-module';
 import { patchAppTestModuleForDefault } from './patch-app-test-module';
 import { resolveProjectPath } from './resolve-project-path';
-import { stripMainOptionalFeatures } from './patch-main';
 import { stripDefineDocumentationAuth } from './patch-define-documentation';
 import { stripEnvAuth } from './patch-env';
 import { pruneCoreAuthForSlimTemplate } from './prune-core-auth';
@@ -231,6 +230,6 @@ function stripDefaultProjectAuth(projectName: string) {
       './security/guards/profiles.guard',
     ]);
     main = main.replace(/\n {2}app\.useGlobalGuards\([\s\S]*?\);\n/, '\n');
-    writeFileSync(mainPath, stripMainOptionalFeatures(main), 'utf8');
+    writeFileSync(mainPath, main, 'utf8');
   }
 }

--- a/libs/doc/markdown/en/application/mapping.md
+++ b/libs/doc/markdown/en/application/mapping.md
@@ -39,7 +39,6 @@ Usage in entity:
 ```typescript
 @OneToMany(() => PersonContact, (contact) => contact.person, {
   cascade: true,
-  eager: true,
   onDelete: 'CASCADE',
 })
 @AutoMap({ type: () => PersonContact })
@@ -99,6 +98,28 @@ return AutoMapper.map(createdPerson, Person, CreatePersonResponse);
 ```
 
 `AutoMapper` resolves properties by name, maps nested objects recursively, and iterates arrays automatically.
+
+### Update with an already-loaded entity
+
+For updates, load the entity from the database and apply the payload manually (as in `UpdatePersonHandler`). Persisted collections must be **replaced** by the request list — the expected behavior with TypeORM `cascade` + `orphanedRowAction: 'delete'`: on save, items missing from the collection become orphans and are removed.
+
+```typescript
+person.contacts = validated.contacts.map((contactRequest) => {
+  if (contactRequest.id) {
+    const existing = person.contacts.find((c) => c.id === contactRequest.id);
+    if (existing) {
+      existing.contact = contactRequest.contact;
+      return existing;
+    }
+  }
+  const contact = new PersonContact();
+  contact.contact = contactRequest.contact;
+  contact.person = person;
+  return contact;
+});
+```
+
+Do not append to persisted collections; `save` treats the list as the full state.
 
 ## Customizing with forMember
 

--- a/libs/doc/markdown/en/core/cron-event-jobs.md
+++ b/libs/doc/markdown/en/core/cron-event-jobs.md
@@ -142,7 +142,7 @@ export abstract class CronJobHandlerBase {
 
 ### Example: DeleteInactiveJob
 
-Removes inactive people every 15 seconds (educational example — short interval for dev demo):
+Removes inactive people every 15 seconds (educational example — short interval for dev demo). The job paginates via `IPersonRepository.findMany` in batches of 100 so it does not depend on the default listing limit:
 
 ```typescript
 import { CronExpression } from '@/core/constants/cron.constants';

--- a/libs/doc/markdown/en/domain/entities.md
+++ b/libs/doc/markdown/en/domain/entities.md
@@ -28,7 +28,6 @@ export class Person extends EntityBase<Person> {
 
   @OneToOne(() => PersonAddress, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @JoinColumn()
@@ -37,7 +36,6 @@ export class Person extends EntityBase<Person> {
 
   @OneToMany(() => PersonContact, (contact) => contact.person, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @AutoMap({ type: () => PersonContact })
@@ -112,8 +110,33 @@ const dataSource = new DataSource({
 
 The `invalidWhereValuesBehavior.undefined: 'ignore'` option prevents optional filters (`undefined`) from generating invalid clauses in TypeORM.
 
+## Loading relations in the repository
+
+Avoid `eager: true` on entities — load relations **explicitly** in the repository per use case:
+
+- **`findById`** — detail with `relations: { address: true, contacts: true }`
+- **`findMany`** — lightweight listing without `relations` (arrays may be normalized to `[]` by `RepositoryBase`)
+
+```typescript
+findById(id: number): Promise<Person | null> {
+  return this.findOneNormalized({
+    where: { id },
+    relations: { address: true, contacts: true },
+  });
+}
+
+findMany(query: PersonQueryDto): Promise<ListResponse<Person>> {
+  return this.repository.findAndCount({ /* no relations */ })
+    .then(([items, count]) => ({
+      items: this.normalizeEntities(items),
+      count,
+    }));
+}
+```
+
 ## Best practices
 
 - Keep entities free of HTTP logic (no `@ApiProperty`).
 - Use `cascade` and `onDelete` according to the aggregate's business rules.
+- Persisted collections are **full state** on `save` — replace the list on update; missing items become orphans with `orphanedRowAction: 'delete'`.
 - Register new entities in `dataSourceFactory` and generate migrations after changes.

--- a/libs/doc/markdown/en/getting-started/environment-variables.md
+++ b/libs/doc/markdown/en/getting-started/environment-variables.md
@@ -20,12 +20,17 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
+  HOST: z.string().default('0.0.0.0'),
   NODE_ENV: z.enum(['test', 'develop', 'staging', 'production']),
   DATABASE_URL: z.string(),
   REDIS_CONNECTION_STRING: z.string().optional(),
   CACHE_KEY_PREFIX: z.string().optional(),
   CRON_JOBS_ENABLED: z.coerce.boolean().default(false),
   BOOTSTRAP_DELAY_MS: z.coerce.number().default(0),
+  RATE_LIMIT_MAX: z.coerce.number().default(0),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60_000),
+  CORS_ORIGINS: z.string().optional(),
+  BCRYPT_ROUNDS: z.coerce.number().min(4).max(15).default(10),
   JWT_PRIVATE_KEY: z.string().optional(),
   JWT_PUBLIC_KEY: z.string().optional(),
   JWT_ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),
@@ -41,9 +46,32 @@ Create a `.env` at the project root (the CLI also copies `.env.example` as a ref
 
 ```env
 PORT=3000
+HOST=0.0.0.0
 NODE_ENV=develop
 DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 ```
+
+### HTTP (CORS and rate limit)
+
+Included in core via `applyHttpMiddleware`. Full guide: [HTTP middleware](../host/http-middleware.md).
+
+```env
+# Optional — comma-separated origins
+# CORS_ORIGINS=http://localhost:4200,https://app.example.com
+
+# Rate limit (0 = disabled)
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+```
+
+| Variable | Description |
+| --- | --- |
+| `HOST` | Server bind address (Docker/K8s); default `0.0.0.0` |
+| `API_HOST` | Public hostname for Swagger and OAuth (`resolveApiHost`) |
+| `CORS_ORIGINS` | When set, limits CORS to listed origins |
+| `RATE_LIMIT_MAX` | Max requests per IP per window; `0` disables |
+| `RATE_LIMIT_WINDOW_MS` | Rate limit window in ms |
+| `BCRYPT_ROUNDS` | Password hash cost (default `10`) |
 
 ### Authentication (when installed)
 

--- a/libs/doc/markdown/en/getting-started/project-structure.md
+++ b/libs/doc/markdown/en/getting-started/project-structure.md
@@ -13,9 +13,10 @@ This guide describes how the NestJS application is initialized and how modules c
 
 ## Entry point
 
-The `src/host/main.ts` file configures CORS, OpenAPI documentation, global error filter, and starts the server. **Core** projects (without auth/cron) stay slim — the CLI removes optional imports and blocks when features were not selected.
+The `src/host/main.ts` file configures OpenAPI documentation, global error filter, and starts the server. CORS, cookies, and rate limit live in `applyHttpMiddleware` (`src/host/bootstrap/`). Details: [HTTP middleware](../host/http-middleware.md). **Core** projects (without auth/cron) stay slim — the CLI removes optional imports and blocks when features were not selected.
 
 ```typescript
+import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { defineDocumentation } from './open-api/define-documentation';
@@ -26,7 +27,7 @@ import { ILoggingService } from '@/domain/common/ilogging.service';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.enableCors({ credentials: true, origin: true, optionsSuccessStatus: 200 });
+  applyHttpMiddleware(app);
 
   await defineDocumentation(app);
 
@@ -39,7 +40,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-**With authentication** (`kl-nest add auth` or selected in `new`): `cookie-parser`, global guards (`AuthGuard`, `ProfilesGuard`).
+**With authentication** (`kl-nest add auth` or selected in `new`): global guards (`AuthGuard`, `ProfilesGuard`). Cookies are already handled by `applyHttpMiddleware`.
 
 **With cron/event jobs** (`kl-nest add cron` / `add events`): infrastructure under `src/core/background-services/` and `JobsModule.register()` in `AppModule` (empty arrays in Default; sample handlers in CRUD).
 

--- a/libs/doc/markdown/en/guides/person-crud-flow.md
+++ b/libs/doc/markdown/en/guides/person-crud-flow.md
@@ -60,14 +60,13 @@ export class Person extends EntityBase<Person> {
   @AutoMap()
   name: string;
 
-  @OneToOne(() => PersonAddress, { cascade: true, eager: true, onDelete: 'CASCADE' })
+  @OneToOne(() => PersonAddress, { cascade: true, onDelete: 'CASCADE' })
   @JoinColumn()
   @AutoMap()
   address: PersonAddress;
 
   @OneToMany(() => PersonContact, (contact) => contact.person, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @AutoMap({ type: () => PersonContact })
@@ -274,3 +273,50 @@ When creating a resource similar to Person, follow the steps in this guide in or
 3. **Infra** — concrete repository, provider in `RepositoryModule`, and entities in `dataSourceFactory`
 4. **Host** — `router.config.ts`, controllers, `<Resource>Module`, and import in `AppModule`
 5. **Migrations** — `migration:generate`, review the generated file, and `migration:run`
+
+## Framework patterns (4.x)
+
+### Query DTOs with `PaginationDto.from()`
+
+Query DTOs do **not** extend `ObjectClass` (partial props). Use the inherited factory:
+
+```typescript
+const query = PersonQueryDto.from({ name: 'Jane', limit: 50 });
+```
+
+### Paginated responses with `ListResponseBase`
+
+Handlers return `MyListResponse.from({ items, count })` instead of duplicating `items`/`count`:
+
+```typescript
+export class ReadManyPersonResponse extends ListResponseBase<ReadManyPersonResponseItem> {}
+```
+
+### Partial entities (import/jobs)
+
+For incomplete props, do **not** use `.from()` — instantiate and assign fields, or call `initializeUndefinedArrayProps(entity, EntityClass)` after `new`.
+
+### `HOST` vs `API_HOST`
+
+- **`HOST`** (default `0.0.0.0`) — server bind address (Docker/K8s).
+- **`API_HOST`** — public hostname for Swagger and OAuth URLs (`resolveApiHost`).
+
+### Default sort in Query DTO
+
+Override `generateOrderBy()` in the query DTO instead of patching the handler:
+
+```typescript
+export class PersonQueryDto extends PaginationDto {
+  override generateOrderBy() {
+    if (this.orderBy) return super.generateOrderBy();
+    return { id: 'asc' };
+  }
+}
+```
+
+### Advanced TypeORM (`PaginationDto`)
+
+- `toFindOptionsOrder()` — converts `generateOrderBy()` to `FindOptionsOrder` (ASC/DESC).
+- `applyQueryBuilderPagination(qb, alias)` — applies order + skip/take on QueryBuilder.
+
+Rate limit is included in core. See [HTTP middleware](../host/http-middleware.md).

--- a/libs/doc/markdown/en/host/http-middleware.md
+++ b/libs/doc/markdown/en/host/http-middleware.md
@@ -1,0 +1,67 @@
+---
+title: HTTP middleware
+slug: http-middleware
+category: host
+docKey: host/middleware-http
+order: 0
+description: CORS, cookies, rate limit, and HTTP bootstrap via applyHttpMiddleware.
+---
+
+# HTTP middleware
+
+CORS, `cookie-parser`, and rate limiting are applied in one place: `applyHttpMiddleware` in `src/host/bootstrap/apply-http-middleware.ts`. `main.ts` calls it right after `NestFactory.create`.
+
+```typescript
+import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  applyHttpMiddleware(app);
+  // ...
+}
+```
+
+## CORS
+
+By default the API accepts **any origin** (`origin: true` with `credentials: true`), aligned with publicly consumable APIs.
+
+To restrict, set `CORS_ORIGINS` in `.env` (comma-separated origins):
+
+```env
+CORS_ORIGINS=http://localhost:4200,https://app.example.com
+```
+
+Resolution lives in `resolveCorsOrigin()` (`src/core/utils/resolve-cors-origins.ts`):
+
+| `CORS_ORIGINS` | Behavior |
+| --- | --- |
+| missing or empty | `true` — reflects the request origin |
+| single origin | string |
+| multiple origins | array of strings |
+
+## Rate limit
+
+Middleware in `src/core/http/rate-limit.middleware.ts`, registered by the bootstrap. **Disabled by default** (`RATE_LIMIT_MAX=0`).
+
+```env
+RATE_LIMIT_MAX=300
+RATE_LIMIT_WINDOW_MS=60000
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RATE_LIMIT_MAX` | `0` | Max requests per IP per window; `0` disables |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | Window in milliseconds |
+
+When the limit is exceeded: HTTP **429** with a JSON message.
+
+## Cookies
+
+`cookie-parser` is registered in the bootstrap — required for refresh token cookies on `/auth/refresh` when JWT auth is installed.
+
+## Tests
+
+- `src/test/core/resolve-cors-origins.spec.ts`
+- `src/test/core/http/rate-limit.middleware.spec.ts`
+
+See also: [Environment variables](../getting-started/environment-variables.md), [Project structure](../getting-started/project-structure.md).

--- a/libs/doc/markdown/en/host/openapi-scalar.md
+++ b/libs/doc/markdown/en/host/openapi-scalar.md
@@ -90,7 +90,7 @@ import { defineDocumentation } from './open-api/define-documentation';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // ... CORS, filters ...
+  // applyHttpMiddleware(app) — see HTTP middleware guide
 
   defineDocumentation(app);
 

--- a/libs/doc/markdown/pt/application/mapeamento.md
+++ b/libs/doc/markdown/pt/application/mapeamento.md
@@ -39,7 +39,6 @@ Uso em entidade:
 ```typescript
 @OneToMany(() => PersonContact, (contact) => contact.person, {
   cascade: true,
-  eager: true,
   onDelete: 'CASCADE',
 })
 @AutoMap({ type: () => PersonContact })
@@ -99,6 +98,28 @@ return AutoMapper.map(createdPerson, Person, CreatePersonResponse);
 ```
 
 O `AutoMapper` resolve propriedades pelo nome, mapeia objetos aninhados recursivamente e itera arrays automaticamente.
+
+### Update com entidade já carregada
+
+Para updates, carregue a entidade do banco e aplique o payload manualmente (como em `UpdatePersonHandler`). Coleções persistidas devem ser **substituídas** pela lista do request — o comportamento esperado com TypeORM `cascade` + `orphanedRowAction: 'delete'`: ao salvar, itens ausentes na coleção viram órfãos e são removidos.
+
+```typescript
+person.contacts = validated.contacts.map((contactRequest) => {
+  if (contactRequest.id) {
+    const existing = person.contacts.find((c) => c.id === contactRequest.id);
+    if (existing) {
+      existing.contact = contactRequest.contact;
+      return existing;
+    }
+  }
+  const contact = new PersonContact();
+  contact.contact = contactRequest.contact;
+  contact.person = person;
+  return contact;
+});
+```
+
+Não use append em coleções persistidas; o `save` trata a lista como estado completo.
 
 ## Customizar com forMember
 

--- a/libs/doc/markdown/pt/core/cron-event-jobs.md
+++ b/libs/doc/markdown/pt/core/cron-event-jobs.md
@@ -142,7 +142,7 @@ export abstract class CronJobHandlerBase {
 
 ### Exemplo: DeleteInactiveJob
 
-Remove pessoas inativas a cada 15 segundos (exemplo didático — intervalo curto para demonstração em dev):
+Remove pessoas inativas a cada 15 segundos (exemplo didático — intervalo curto para demonstração em dev). O job pagina via `IPersonRepository.findMany` em lotes de 100 para não depender do limite padrão de listagem:
 
 ```typescript
 import { CronExpression } from '@/core/constants/cron.constants';

--- a/libs/doc/markdown/pt/domain/entidades.md
+++ b/libs/doc/markdown/pt/domain/entidades.md
@@ -28,7 +28,6 @@ export class Person extends EntityBase<Person> {
 
   @OneToOne(() => PersonAddress, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @JoinColumn()
@@ -37,7 +36,6 @@ export class Person extends EntityBase<Person> {
 
   @OneToMany(() => PersonContact, (contact) => contact.person, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @AutoMap({ type: () => PersonContact })
@@ -112,8 +110,33 @@ const dataSource = new DataSource({
 
 A opção `invalidWhereValuesBehavior.undefined: 'ignore'` evita que filtros opcionais (`undefined`) gerem cláusulas inválidas no TypeORM.
 
+## Carregar relacionamentos no repositório
+
+Evite `eager: true` nas entidades — carregue relations **explicitamente** no repositório conforme o caso de uso:
+
+- **`findById`** — detalhe com `relations: { address: true, contacts: true }`
+- **`findMany`** — listagem leve, sem `relations` (arrays podem ser normalizados como `[]` pelo `RepositoryBase`)
+
+```typescript
+findById(id: number): Promise<Person | null> {
+  return this.findOneNormalized({
+    where: { id },
+    relations: { address: true, contacts: true },
+  });
+}
+
+findMany(query: PersonQueryDto): Promise<ListResponse<Person>> {
+  return this.repository.findAndCount({ /* sem relations */ })
+    .then(([items, count]) => ({
+      items: this.normalizeEntities(items),
+      count,
+    }));
+}
+```
+
 ## Boas práticas
 
 - Mantenha entidades livres de lógica HTTP (sem `@ApiProperty`).
 - Use `cascade` e `onDelete` conforme a regra de negócio do agregado.
+- Coleções persistidas são **estado completo** no `save` — substitua a lista no update; itens ausentes viram órfãos com `orphanedRowAction: 'delete'`.
 - Registre novas entidades no `dataSourceFactory` e gere migrations após alterações.

--- a/libs/doc/markdown/pt/guias/fluxo-crud-person.md
+++ b/libs/doc/markdown/pt/guias/fluxo-crud-person.md
@@ -60,14 +60,13 @@ export class Person extends EntityBase<Person> {
   @AutoMap()
   name: string;
 
-  @OneToOne(() => PersonAddress, { cascade: true, eager: true, onDelete: 'CASCADE' })
+  @OneToOne(() => PersonAddress, { cascade: true, onDelete: 'CASCADE' })
   @JoinColumn()
   @AutoMap()
   address: PersonAddress;
 
   @OneToMany(() => PersonContact, (contact) => contact.person, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @AutoMap({ type: () => PersonContact })
@@ -274,3 +273,50 @@ Ao criar um recurso semelhante ao Person, percorra as etapas deste guia nesta or
 3. **Infra** — repositório concreto, provider no `RepositoryModule` e entidades no `dataSourceFactory`
 4. **Host** — `router.config.ts`, controllers, `<Recurso>Module` e import no `AppModule`
 5. **Migrations** — `migration:generate`, revisão do arquivo gerado e `migration:run`
+
+## Padrões de framework (4.x)
+
+### Query DTOs com `PaginationDto.from()`
+
+DTOs de consulta **não** estendem `ObjectClass` (props parciais). Use a factory herdada:
+
+```typescript
+const query = PersonQueryDto.from({ name: 'Jane', limit: 50 });
+```
+
+### Respostas paginadas com `ListResponseBase`
+
+Handlers retornam `MinhaListResponse.from({ items, count })` em vez de duplicar `items`/`count`:
+
+```typescript
+export class ReadManyPersonResponse extends ListResponseBase<ReadManyPersonResponseItem> {}
+```
+
+### Entidades parciais (import/jobs)
+
+Para montagem com props incompletas, **não** use `.from()` — instancie e atribua campos, ou chame `initializeUndefinedArrayProps(entity, EntityClass)` após o `new`.
+
+### `HOST` vs `API_HOST`
+
+- **`HOST`** (default `0.0.0.0`) — endereço de bind do servidor (Docker/K8s).
+- **`API_HOST`** — hostname público para Swagger e URLs OAuth (`resolveApiHost`).
+
+### Ordenação padrão no Query DTO
+
+Override `generateOrderBy()` no DTO de consulta em vez de alterar o handler:
+
+```typescript
+export class PersonQueryDto extends PaginationDto {
+  override generateOrderBy() {
+    if (this.orderBy) return super.generateOrderBy();
+    return { id: 'asc' };
+  }
+}
+```
+
+### TypeORM avançado (`PaginationDto`)
+
+- `toFindOptionsOrder()` — converte `generateOrderBy()` para `FindOptionsOrder` (ASC/DESC).
+- `applyQueryBuilderPagination(qb, alias)` — aplica order + skip/take no QueryBuilder.
+
+Rate limit já vem no core. Veja [Middleware HTTP](../host/middleware-http.md).

--- a/libs/doc/markdown/pt/host/middleware-http.md
+++ b/libs/doc/markdown/pt/host/middleware-http.md
@@ -1,0 +1,67 @@
+---
+title: Middleware HTTP
+slug: middleware-http
+category: host
+docKey: host/middleware-http
+order: 0
+description: CORS, cookies, rate limit e bootstrap HTTP via applyHttpMiddleware.
+---
+
+# Middleware HTTP
+
+CORS, `cookie-parser` e rate limit são aplicados em um único ponto: `applyHttpMiddleware` em `src/host/bootstrap/apply-http-middleware.ts`. O `main.ts` chama essa função logo após `NestFactory.create`.
+
+```typescript
+import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  applyHttpMiddleware(app);
+  // ...
+}
+```
+
+## CORS
+
+Por padrão a API aceita **qualquer origin** (`origin: true` com `credentials: true`), alinhado ao princípio de APIs públicas e consumíveis por qualquer cliente.
+
+Para restringir, defina `CORS_ORIGINS` no `.env` (origens separadas por vírgula):
+
+```env
+CORS_ORIGINS=http://localhost:4200,https://app.example.com
+```
+
+A resolução fica em `resolveCorsOrigin()` (`src/core/utils/resolve-cors-origins.ts`):
+
+| `CORS_ORIGINS` | Comportamento |
+| --- | --- |
+| ausente ou vazio | `true` — reflete a origin da requisição |
+| uma origem | string única |
+| várias origens | array de strings |
+
+## Rate limit
+
+Middleware em `src/core/http/rate-limit.middleware.ts`, registrado pelo bootstrap. **Desabilitado por padrão** (`RATE_LIMIT_MAX=0`).
+
+```env
+RATE_LIMIT_MAX=300
+RATE_LIMIT_WINDOW_MS=60000
+```
+
+| Variável | Default | Descrição |
+| --- | --- | --- |
+| `RATE_LIMIT_MAX` | `0` | Máximo de requisições por IP na janela; `0` desliga |
+| `RATE_LIMIT_WINDOW_MS` | `60000` | Janela em milissegundos |
+
+Resposta ao exceder o limite: HTTP **429** com mensagem JSON padronizada.
+
+## Cookies
+
+`cookie-parser` é registrado no bootstrap — necessário para refresh token em cookie (`/auth/refresh`) quando autenticação JWT está instalada.
+
+## Testes
+
+- `src/test/core/resolve-cors-origins.spec.ts`
+- `src/test/core/http/rate-limit.middleware.spec.ts`
+
+Veja também: [Variáveis de ambiente](../inicio/variaveis-de-ambiente.md), [Estrutura do projeto](../inicio/estrutura-do-projeto.md).

--- a/libs/doc/markdown/pt/host/openapi-scalar.md
+++ b/libs/doc/markdown/pt/host/openapi-scalar.md
@@ -90,7 +90,7 @@ import { defineDocumentation } from './open-api/define-documentation';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // ... CORS, filtros ...
+  // applyHttpMiddleware(app) — ver Middleware HTTP
 
   defineDocumentation(app);
 

--- a/libs/doc/markdown/pt/inicio/estrutura-do-projeto.md
+++ b/libs/doc/markdown/pt/inicio/estrutura-do-projeto.md
@@ -13,9 +13,10 @@ Este guia descreve como a aplicação NestJS é inicializada e como os módulos 
 
 ## Ponto de entrada
 
-O arquivo `src/host/main.ts` configura CORS, documentação OpenAPI, filtro global de erros e inicia o servidor. Projetos **core** (sem auth/cron) ficam enxutos — a CLI remove imports e trechos opcionais quando as features não são selecionadas.
+O arquivo `src/host/main.ts` configura documentação OpenAPI, filtro global de erros e inicia o servidor. CORS, cookies e rate limit ficam em `applyHttpMiddleware` (`src/host/bootstrap/`). Detalhes: [Middleware HTTP](../host/middleware-http.md). Projetos **core** (sem auth/cron) ficam enxutos — a CLI remove imports e trechos opcionais quando as features não são selecionadas.
 
 ```typescript
+import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { defineDocumentation } from './open-api/define-documentation';
@@ -26,7 +27,7 @@ import { ILoggingService } from '@/domain/common/ilogging.service';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.enableCors({ credentials: true, origin: true, optionsSuccessStatus: 200 });
+  applyHttpMiddleware(app);
 
   await defineDocumentation(app);
 
@@ -39,7 +40,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-**Com autenticação** (`kl-nest add auth` ou seleção no `new`): `cookie-parser`, guards globais (`AuthGuard`, `ProfilesGuard`).
+**Com autenticação** (`kl-nest add auth` ou seleção no `new`): guards globais (`AuthGuard`, `ProfilesGuard`). Cookies já passam pelo `applyHttpMiddleware`.
 
 **Com cron/event jobs** (`kl-nest add cron` / `add events`): infraestrutura em `src/core/background-services/` e `JobsModule.register()` no `AppModule` (arrays vazios no template Padrão; handlers de exemplo no CRUD).
 

--- a/libs/doc/markdown/pt/inicio/variaveis-de-ambiente.md
+++ b/libs/doc/markdown/pt/inicio/variaveis-de-ambiente.md
@@ -20,12 +20,17 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
+  HOST: z.string().default('0.0.0.0'),
   NODE_ENV: z.enum(['test', 'develop', 'staging', 'production']),
   DATABASE_URL: z.string(),
   REDIS_CONNECTION_STRING: z.string().optional(),
   CACHE_KEY_PREFIX: z.string().optional(),
   CRON_JOBS_ENABLED: z.coerce.boolean().default(false),
   BOOTSTRAP_DELAY_MS: z.coerce.number().default(0),
+  RATE_LIMIT_MAX: z.coerce.number().default(0),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60_000),
+  CORS_ORIGINS: z.string().optional(),
+  BCRYPT_ROUNDS: z.coerce.number().min(4).max(15).default(10),
   JWT_PRIVATE_KEY: z.string().optional(),
   JWT_PUBLIC_KEY: z.string().optional(),
   JWT_ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),
@@ -41,9 +46,32 @@ Crie um `.env` na raiz do projeto (a CLI também copia `.env.example` como refer
 
 ```env
 PORT=3000
+HOST=0.0.0.0
 NODE_ENV=develop
 DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 ```
+
+### HTTP (CORS e rate limit)
+
+Já vêm no core via `applyHttpMiddleware`. Guia completo: [Middleware HTTP](../host/middleware-http.md).
+
+```env
+# Opcional — origens separadas por vírgula
+# CORS_ORIGINS=http://localhost:4200,https://app.example.com
+
+# Rate limit (0 = desabilitado)
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+```
+
+| Variável | Descrição |
+| --- | --- |
+| `HOST` | Endereço de bind do servidor (Docker/K8s); default `0.0.0.0` |
+| `API_HOST` | Hostname público para Swagger e OAuth (`resolveApiHost`) |
+| `CORS_ORIGINS` | Quando definido, limita CORS às origens listadas |
+| `RATE_LIMIT_MAX` | Máximo de requisições por IP na janela; `0` desliga |
+| `RATE_LIMIT_WINDOW_MS` | Janela do rate limit em ms |
+| `BCRYPT_ROUNDS` | Custo do hash de senha (default `10`) |
 
 ### Autenticação (quando instalada)
 

--- a/libs/doc/site/public/llm-en.txt
+++ b/libs/doc/site/public/llm-en.txt
@@ -38,6 +38,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Host
 
+- [HTTP middleware](markdown/en/host/http-middleware.md): CORS, cookies, rate limit, and HTTP bootstrap via applyHttpMiddleware.
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.

--- a/libs/doc/site/public/llm.txt
+++ b/libs/doc/site/public/llm.txt
@@ -38,6 +38,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Host
 
+- [Middleware HTTP](markdown/pt/host/middleware-http.md): CORS, cookies, rate limit e bootstrap HTTP via applyHttpMiddleware.
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.

--- a/libs/doc/site/public/llms-en.txt
+++ b/libs/doc/site/public/llms-en.txt
@@ -38,6 +38,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Host
 
+- [HTTP middleware](markdown/en/host/http-middleware.md): CORS, cookies, rate limit, and HTTP bootstrap via applyHttpMiddleware.
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.

--- a/libs/doc/site/public/llms.txt
+++ b/libs/doc/site/public/llms.txt
@@ -38,6 +38,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Host
 
+- [Middleware HTTP](markdown/pt/host/middleware-http.md): CORS, cookies, rate limit e bootstrap HTTP via applyHttpMiddleware.
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.

--- a/libs/doc/txt/llm-en.txt
+++ b/libs/doc/txt/llm-en.txt
@@ -38,6 +38,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Host
 
+- [HTTP middleware](markdown/en/host/http-middleware.md): CORS, cookies, rate limit, and HTTP bootstrap via applyHttpMiddleware.
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.

--- a/libs/doc/txt/llm.txt
+++ b/libs/doc/txt/llm.txt
@@ -38,6 +38,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Host
 
+- [Middleware HTTP](markdown/pt/host/middleware-http.md): CORS, cookies, rate limit e bootstrap HTTP via applyHttpMiddleware.
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.

--- a/libs/doc/txt/llms-en.txt
+++ b/libs/doc/txt/llms-en.txt
@@ -38,6 +38,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Host
 
+- [HTTP middleware](markdown/en/host/http-middleware.md): CORS, cookies, rate limit, and HTTP bootstrap via applyHttpMiddleware.
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.

--- a/libs/doc/txt/llms.txt
+++ b/libs/doc/txt/llms.txt
@@ -38,6 +38,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Host
 
+- [Middleware HTTP](markdown/pt/host/middleware-http.md): CORS, cookies, rate limit e bootstrap HTTP via applyHttpMiddleware.
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.

--- a/libs/koala-nest/.env.example
+++ b/libs/koala-nest/.env.example
@@ -1,4 +1,6 @@
 PORT=3000
+# Endereço de bind do servidor (Docker/K8s). URLs públicas usam API_HOST.
+HOST=0.0.0.0
 NODE_ENV=develop
 DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 
@@ -11,6 +13,16 @@ DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 # Cron jobs de exemplo (create/delete person). Habilitado no template para demonstração em dev.
 CRON_JOBS_ENABLED=true
 BOOTSTRAP_DELAY_MS=0
+
+# Rate limit (0 = desabilitado)
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+
+# CORS — aberto por padrão; restrinja com origens separadas por vírgula se necessário
+# CORS_ORIGINS=http://localhost:4200,https://app.example.com
+
+# Custo do bcrypt (padrão 10)
+# BCRYPT_ROUNDS=10
 
 # JWT (RS256 — chaves em base64) — ative com `kl-nest new --auth jwt` ou `kl-nest add auth jwt`
 JWT_PRIVATE_KEY=

--- a/libs/koala-nest/src/application/common/pagination.request.ts
+++ b/libs/koala-nest/src/application/common/pagination.request.ts
@@ -3,11 +3,6 @@ import { AutoMap } from '@/core/tools/mapping';
 import type { QueryDirectionType } from '@/core/types';
 import { ApiProperty } from '@nestjs/swagger';
 
-export type PaginatedRequestProps<T extends PaginationRequest> = Omit<
-  { [K in keyof T as T[K] extends Function ? never : K]: T[K] },
-  '_id'
->;
-
 export class PaginationRequest {
   @ApiProperty({
     required: false,

--- a/libs/koala-nest/src/application/mapping/person.mapper.ts
+++ b/libs/koala-nest/src/application/mapping/person.mapper.ts
@@ -15,11 +15,6 @@ import {
   ReadPersonContactResponse,
   ReadPersonResponse,
 } from '@/application/person/read/read-person.response';
-import {
-  UpdatePersonAddressRequest,
-  UpdatePersonContactRequest,
-  UpdatePersonRequest,
-} from '@/application/person/update/update-person.request';
 import { ReadManyPersonResponseItem } from '@/application/person/read-many/read-many-person.response';
 
 export class PersonMapper {
@@ -33,10 +28,6 @@ export class PersonMapper {
     createMap(CreatePersonRequest, Person);
     createMap(CreatePersonAddressRequest, PersonAddress);
     createMap(CreatePersonContactRequest, PersonContact);
-
-    createMap(UpdatePersonRequest, Person);
-    createMap(UpdatePersonAddressRequest, PersonAddress);
-    createMap(UpdatePersonContactRequest, PersonContact);
 
     createMap(ReadManyPersonRequest, PersonQueryDto);
     createMap(Person, ReadManyPersonResponseItem);

--- a/libs/koala-nest/src/application/person/jobs/cron/delete-inactive.job.ts
+++ b/libs/koala-nest/src/application/person/jobs/cron/delete-inactive.job.ts
@@ -1,15 +1,17 @@
 import { CronExpression } from '@/core/constants/cron.constants';
 import { DeletePersonHandler } from '@/application/person/delete/delete-person.handler';
-import { ReadManyPersonHandler } from '@/application/person/read-many/read-many-person.handler';
-import { ReadManyPersonRequest } from '@/application/person/read-many/read-many-person.request';
 import {
   CronJobHandlerBase,
   CronJobSettings,
   cronJobSettings,
 } from '@/core/background-services/cron-service/cron-job.handler.base';
+import { PersonQueryDto } from '@/domain/dtos/person-query.dto';
 import { ILoggingService } from '@/domain/common/ilogging.service';
 import { IRedLockService } from '@/domain/common/ired-lock.service';
+import { IPersonRepository } from '@/domain/repositories/iperson.repository';
 import { Injectable, Logger } from '@nestjs/common';
+
+const DELETE_INACTIVE_BATCH_SIZE = 100;
 
 @Injectable()
 export class DeleteInactiveJob extends CronJobHandlerBase {
@@ -18,7 +20,7 @@ export class DeleteInactiveJob extends CronJobHandlerBase {
   constructor(
     redlockService: IRedLockService,
     loggingService: ILoggingService,
-    private readonly readManyPerson: ReadManyPersonHandler,
+    private readonly repository: IPersonRepository,
     private readonly deletePerson: DeletePersonHandler,
   ) {
     super(redlockService, loggingService);
@@ -31,27 +33,42 @@ export class DeleteInactiveJob extends CronJobHandlerBase {
   protected async run(): Promise<void> {
     this.logger.debug('Iniciando remoção de pessoas inativas...');
 
-    const request = new ReadManyPersonRequest();
-    request.active = false;
+    let page = 0;
+    let totalDeleted = 0;
 
-    const result = await this.readManyPerson.handle(request);
+    while (true) {
+      const query = PersonQueryDto.from({
+        active: false,
+        page,
+        limit: DELETE_INACTIVE_BATCH_SIZE,
+      });
+      const { items, count } = await this.repository.findMany(query);
 
-    if (result.items.length === 0) {
+      if (items.length === 0) {
+        break;
+      }
+
+      this.logger.debug('Removendo pessoas inativas...', items.length);
+
+      for (const person of items) {
+        await this.deletePerson.handle(person.id);
+      }
+
+      totalDeleted += items.length;
+      page += 1;
+
+      if (page * DELETE_INACTIVE_BATCH_SIZE >= count) {
+        break;
+      }
+    }
+
+    if (totalDeleted === 0) {
       this.logger.log('Nenhuma pessoa inativa encontrada.');
       this.logger.log('Job concluído sem ação.');
       return;
     }
 
-    this.logger.debug('Removendo pessoas inativas...', result.items.length);
-
-    for (const person of result.items) {
-      await this.deletePerson.handle(person.id);
-    }
-
-    this.logger.log(
-      'Pessoas inativas removidas com sucesso.',
-      result.items.length,
-    );
+    this.logger.log('Pessoas inativas removidas com sucesso.', totalDeleted);
     this.logger.log('Job concluído.');
   }
 }

--- a/libs/koala-nest/src/application/person/read-many/read-many-person.response.ts
+++ b/libs/koala-nest/src/application/person/read-many/read-many-person.response.ts
@@ -1,6 +1,5 @@
-import { ObjectClass } from '@/core/base/object-class';
+import { ListResponseBase } from '@/core/common/list-response.base';
 import { AutoMap } from '@/core/tools/mapping';
-import { ListResponse } from '@/core/types';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ReadManyPersonResponseItem {
@@ -17,14 +16,4 @@ export class ReadManyPersonResponseItem {
   active: boolean;
 }
 
-export class ReadManyPersonResponse extends ObjectClass<
-  ListResponse<ReadManyPersonResponseItem>
-> {
-  @ApiProperty({ type: [ReadManyPersonResponseItem] })
-  @AutoMap({ type: () => ReadManyPersonResponseItem })
-  items: ReadManyPersonResponseItem[];
-
-  @ApiProperty()
-  @AutoMap()
-  count: number;
-}
+export class ReadManyPersonResponse extends ListResponseBase<ReadManyPersonResponseItem> {}

--- a/libs/koala-nest/src/core/background-services/cron-service/cron-job.handler.base.ts
+++ b/libs/koala-nest/src/core/background-services/cron-service/cron-job.handler.base.ts
@@ -1,6 +1,9 @@
 import { ILoggingService } from '@/domain/common/ilogging.service';
 import { IRedLockService } from '@/domain/common/ired-lock.service';
-import { cronExpressionToBoolean } from '@/core/utils/cron-expression-to-boolean';
+import {
+  cronExpressionToBoolean,
+  getCronExecutionKey,
+} from '@/core/utils/cron-expression-to-boolean';
 import { DEFAULT_CRON_POLL_MINUTES } from '@/core/constants/cron.constants';
 import { MINUTES_TO_MS, MS_TO_SECONDS } from '@/core/utils/time.constants';
 import { delay } from '@koalarx/utils/KlDelay';
@@ -9,6 +12,7 @@ import { reportErrorToLogging } from '@/core/utils/report-error';
 export interface CronJobSettings {
   isActive: boolean;
   timeInMinutes: number;
+  cronExpression?: string;
 }
 
 export function cronJobSettings(
@@ -18,10 +22,13 @@ export function cronJobSettings(
   return {
     isActive: cronExpressionToBoolean(cronExpression),
     timeInMinutes,
+    cronExpression,
   };
 }
 
 export abstract class CronJobHandlerBase {
+  private lastExecutedCronKey: string | null = null;
+
   constructor(
     private readonly redlockService: IRedLockService,
     private readonly loggingService: ILoggingService,
@@ -39,22 +46,36 @@ export abstract class CronJobHandlerBase {
       const timeout = settings.timeInMinutes * MINUTES_TO_MS;
 
       if (settings.isActive) {
-        const ttlSecondsLock = timeout / MS_TO_SECONDS;
-        const acquiredLock = await this.redlockService.acquiredLock(
-          name,
-          ttlSecondsLock,
-        );
+        const executionKey = settings.cronExpression
+          ? getCronExecutionKey(settings.cronExpression)
+          : null;
 
-        if (acquiredLock) {
-          try {
-            await this.run();
-          } catch (error) {
-            const reportError =
-              error instanceof Error ? error : new Error(String(error));
+        const alreadyExecutedThisTick =
+          executionKey !== null &&
+          executionKey === this.lastExecutedCronKey;
 
-            await reportErrorToLogging(this.loggingService, reportError);
-          } finally {
-            await this.redlockService.releaseLock(name);
+        if (!alreadyExecutedThisTick) {
+          const ttlSecondsLock = timeout / MS_TO_SECONDS;
+          const acquiredLock = await this.redlockService.acquiredLock(
+            name,
+            ttlSecondsLock,
+          );
+
+          if (acquiredLock) {
+            try {
+              await this.run();
+            } catch (error) {
+              const reportError =
+                error instanceof Error ? error : new Error(String(error));
+
+              await reportErrorToLogging(this.loggingService, reportError);
+            } finally {
+              if (executionKey !== null) {
+                this.lastExecutedCronKey = executionKey;
+              }
+
+              await this.redlockService.releaseLock(name);
+            }
           }
         }
       }

--- a/libs/koala-nest/src/core/background-services/event-service/event-queue.ts
+++ b/libs/koala-nest/src/core/background-services/event-service/event-queue.ts
@@ -1,4 +1,3 @@
-import { IComparableId } from '@/core/utils/icomparable';
 import { EventClass } from './event-class';
 import { EventJob } from './event-job';
 
@@ -62,7 +61,7 @@ export class EventQueue {
     }
   }
 
-  static dispatchEventsForAggregate(id: IComparableId) {
+  static dispatchEventsForAggregate(id: string) {
     const aggregate = this.findMarkedAggregateByID(id);
 
     if (aggregate) {
@@ -96,7 +95,7 @@ export class EventQueue {
   }
 
   static findMarkedAggregateByID(
-    id: IComparableId,
+    id: string,
   ): EventJob<unknown> | undefined {
     return this.markedAggregates.find((aggregate) => aggregate._id === id);
   }

--- a/libs/koala-nest/src/core/common/list-response.base.ts
+++ b/libs/koala-nest/src/core/common/list-response.base.ts
@@ -1,0 +1,10 @@
+import { ObjectClass } from '@/core/base/object-class';
+import { AutoMap } from '@/core/tools/mapping';
+
+export class ListResponseBase<T> extends ObjectClass<ListResponseBase<T>> {
+  @AutoMap()
+  items!: T[];
+
+  @AutoMap()
+  count!: number;
+}

--- a/libs/koala-nest/src/core/env.ts
+++ b/libs/koala-nest/src/core/env.ts
@@ -8,12 +8,17 @@ import { z } from 'zod';
 
 export const envSchema = z.object({
   PORT: z.coerce.number().default(3000),
+  HOST: z.string().default('0.0.0.0'),
   NODE_ENV: z.enum(['test', 'develop', 'staging', 'production']),
   DATABASE_URL: z.string(),
   REDIS_CONNECTION_STRING: z.string().optional(),
   CACHE_KEY_PREFIX: z.string().optional(),
   CRON_JOBS_ENABLED: envBooleanSchema(false),
   BOOTSTRAP_DELAY_MS: z.coerce.number().default(0),
+  RATE_LIMIT_MAX: z.coerce.number().default(0),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60_000),
+  CORS_ORIGINS: z.string().optional(),
+  BCRYPT_ROUNDS: z.coerce.number().min(4).max(15).default(10),
   JWT_PRIVATE_KEY: z.string().optional(),
   JWT_PUBLIC_KEY: z.string().optional(),
   JWT_ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),

--- a/libs/koala-nest/src/core/http/rate-limit.middleware.ts
+++ b/libs/koala-nest/src/core/http/rate-limit.middleware.ts
@@ -1,0 +1,36 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export interface RateLimitOptions {
+  windowMs: number;
+  maxRequests: number;
+}
+
+export function createRateLimitMiddleware(options: RateLimitOptions) {
+  const hits = new Map<string, number[]>();
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (options.maxRequests <= 0) {
+      next();
+      return;
+    }
+
+    const key = req.ip ?? req.socket.remoteAddress ?? 'unknown';
+    const now = Date.now();
+    const windowStart = now - options.windowMs;
+    const timestamps = (hits.get(key) ?? []).filter(
+      (timestamp) => timestamp > windowStart,
+    );
+
+    if (timestamps.length >= options.maxRequests) {
+      res.status(429).json({
+        statusCode: 429,
+        message: 'Muitas requisições. Tente novamente em instantes.',
+      });
+      return;
+    }
+
+    timestamps.push(now);
+    hits.set(key, timestamps);
+    next();
+  };
+}

--- a/libs/koala-nest/src/core/tools/mapping/auto-map.ts
+++ b/libs/koala-nest/src/core/tools/mapping/auto-map.ts
@@ -3,12 +3,36 @@ import { MappingStore } from './mapping-store';
 
 interface AutoMapConfig<T> {
   type?: () => Type<T>;
+  isArray?: boolean;
 }
 
 export function AutoMap<T>(config?: AutoMapConfig<T>) {
-  return function (target: any, propertyKey: string) {
-    const compositionType: (() => any) | undefined = config?.type;
+  return function (target: object, propertyKey: string) {
+    const designType = Reflect.getMetadata('design:type', target, propertyKey);
+    const isArray = config?.isArray ?? designType === Array;
 
-    MappingStore.setProp(target.constructor, propertyKey, compositionType);
+    if (config?.type) {
+      if (isArray) {
+        Reflect.defineMetadata(
+          'composition:type',
+          config.type,
+          target,
+          propertyKey,
+        );
+      } else if (!designType) {
+        Reflect.defineMetadata(
+          'design:type',
+          config.type(),
+          target,
+          propertyKey,
+        );
+      }
+    }
+
+    MappingStore.setProp(
+      (target as { constructor: Type<unknown> }).constructor,
+      propertyKey,
+      config?.type,
+    );
   };
 }

--- a/libs/koala-nest/src/core/tools/mapping/auto-mapper.ts
+++ b/libs/koala-nest/src/core/tools/mapping/auto-mapper.ts
@@ -1,3 +1,4 @@
+import { initializeUndefinedArrayProps } from '@/core/utils/initialize-undefined-array-props';
 import { Type } from '@nestjs/common';
 import { MappingStore } from './mapping-store';
 
@@ -25,7 +26,6 @@ export class AutoMapper {
 
   static map<S, R>(data: any, source: Type<S>, target: Type<R>): R {
     const mapping = MappingStore.getMapping(source, target);
-
     const targetInstance = new target();
 
     if (!mapping) {
@@ -70,9 +70,14 @@ export class AutoMapper {
         }
 
         const targetClass: Type<any> = this.toClass(targetPropType);
+        const sourceValue = data[sourceProp.name];
+
+        if (sourceValue === undefined) {
+          continue;
+        }
 
         targetInstance[targetPropName] = this.map(
-          data[sourceProp.name],
+          sourceValue,
           sourcePropTypeClass,
           targetClass,
         );
@@ -80,17 +85,21 @@ export class AutoMapper {
       }
 
       if (sourceProp.isArray) {
-        targetInstance[targetPropName] = data[sourceProp.name].map(
-          (item: unknown) => {
-            const targetItemType = targetProps.find(
-              (p) => p.name === targetPropName,
-            )!.type;
+        const sourceArray = data[sourceProp.name];
 
-            const targetClassType = this.toClass(targetItemType);
+        if (sourceArray === undefined) {
+          continue;
+        }
 
-            return this.map(item, sourcePropTypeClass, targetClassType);
-          },
-        );
+        targetInstance[targetPropName] = sourceArray.map((item: unknown) => {
+          const targetItemType = targetProps.find(
+            (p) => p.name === targetPropName,
+          )!.type;
+
+          const targetClassType = this.toClass(targetItemType);
+
+          return this.map(item, sourcePropTypeClass, targetClassType);
+        });
         continue;
       }
 
@@ -100,6 +109,11 @@ export class AutoMapper {
         targetInstance[targetPropName] = sourceValue;
       }
     }
+
+    initializeUndefinedArrayProps(
+      targetInstance as Record<string, unknown>,
+      target,
+    );
 
     return targetInstance;
   }

--- a/libs/koala-nest/src/core/tools/mapping/mapping-store.ts
+++ b/libs/koala-nest/src/core/tools/mapping/mapping-store.ts
@@ -30,8 +30,15 @@ export class MappingStore {
       entity.prototype,
       propName,
     );
-    const isArray = propType === Array;
-    const type = isArray ? (compositionType ?? propType) : propType;
+    const explicitComposition = Reflect.getMetadata(
+      'composition:type',
+      entity.prototype,
+      propName,
+    );
+    const isArray = propType === Array || explicitComposition != null;
+    const type = isArray
+      ? (compositionType ?? explicitComposition ?? propType)
+      : propType;
 
     const props = this._entities.get(entity) || [];
 
@@ -62,6 +69,10 @@ export class MappingStore {
     }
 
     return props;
+  }
+
+  static getAllProps(entity: Type<any>) {
+    return this.getProps(entity);
   }
 
   static getPropType(entity: Type<any>, propName: string) {
@@ -112,18 +123,5 @@ export class MappingStore {
 
   static getMapping(source: Type<any>, target: Type<any>) {
     return this._mappings.get(source)?.get(target) ?? null;
-  }
-
-  /** Compatibilidade com chave legada usada em testes. */
-  static getMappingByName(mapName: string) {
-    for (const targetMappings of this._mappings.values()) {
-      for (const mapping of targetMappings.values()) {
-        if (`${mapping.source.name}To${mapping.target.name}` === mapName) {
-          return mapping;
-        }
-      }
-    }
-
-    return null;
   }
 }

--- a/libs/koala-nest/src/core/utils/cron-expression-to-boolean.ts
+++ b/libs/koala-nest/src/core/utils/cron-expression-to-boolean.ts
@@ -1,6 +1,37 @@
 import { CronExpressionParser } from 'cron-parser';
 
 /**
+ * Retorna uma chave única do tick cron atual, ou null se o instante não coincide.
+ */
+export function getCronExecutionKey(
+  cronExpression: string,
+  now: Date = new Date(),
+): string | null {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, {
+      currentDate: now,
+    });
+    const prev = interval.prev();
+
+    const matches =
+      prev.getFullYear() === now.getFullYear() &&
+      prev.getMonth() === now.getMonth() &&
+      prev.getDate() === now.getDate() &&
+      prev.getHours() === now.getHours() &&
+      prev.getMinutes() === now.getMinutes() &&
+      prev.getSeconds() === now.getSeconds();
+
+    if (!matches) {
+      return null;
+    }
+
+    return prev.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Verifica se a expressão cron corresponde ao momento atual.
  *
  * @param cronExpression Expressão cron a ser validada
@@ -45,21 +76,5 @@ export function cronExpressionToBoolean(
   cronExpression: string,
   now: Date = new Date(),
 ): boolean {
-  try {
-    const interval = CronExpressionParser.parse(cronExpression, {
-      currentDate: now,
-    });
-    const prev = interval.prev();
-
-    return (
-      prev.getFullYear() === now.getFullYear() &&
-      prev.getMonth() === now.getMonth() &&
-      prev.getDate() === now.getDate() &&
-      prev.getHours() === now.getHours() &&
-      prev.getMinutes() === now.getMinutes() &&
-      prev.getSeconds() === now.getSeconds()
-    );
-  } catch {
-    return false;
-  }
+  return getCronExecutionKey(cronExpression, now) !== null;
 }

--- a/libs/koala-nest/src/core/utils/hash-password.ts
+++ b/libs/koala-nest/src/core/utils/hash-password.ts
@@ -1,5 +1,10 @@
 import { hash } from 'bcrypt';
 
-export function hashPassword(password: string): Promise<string> {
-  return hash(password, 6);
+const DEFAULT_BCRYPT_ROUNDS = 10;
+
+export function hashPassword(
+  password: string,
+  rounds = Number(process.env.BCRYPT_ROUNDS) || DEFAULT_BCRYPT_ROUNDS,
+): Promise<string> {
+  return hash(password, rounds);
 }

--- a/libs/koala-nest/src/core/utils/icomparable.ts
+++ b/libs/koala-nest/src/core/utils/icomparable.ts
@@ -1,1 +1,0 @@
-export type IComparableId = string | number;

--- a/libs/koala-nest/src/core/utils/initialize-undefined-array-props.ts
+++ b/libs/koala-nest/src/core/utils/initialize-undefined-array-props.ts
@@ -1,0 +1,20 @@
+import type { Type } from '@nestjs/common';
+import { MappingStore } from '@/core/tools/mapping/mapping-store';
+
+export function initializeUndefinedArrayProps(
+  target: Record<string, unknown>,
+  entity: Type<unknown>,
+  onlyProps?: string[],
+): void {
+  MappingStore.getAllProps(entity).forEach((prop) => {
+    if (onlyProps && !onlyProps.includes(prop.name)) {
+      return;
+    }
+
+    if (target[prop.name] !== undefined || !prop.isArray) {
+      return;
+    }
+
+    target[prop.name] = [];
+  });
+}

--- a/libs/koala-nest/src/core/utils/resolve-cors-origins.ts
+++ b/libs/koala-nest/src/core/utils/resolve-cors-origins.ts
@@ -1,0 +1,24 @@
+/**
+ * CORS aberto por padrão (`true` = reflete a origin da requisição).
+ * Defina `CORS_ORIGINS` apenas quando quiser restringir a origens específicas.
+ */
+export function resolveCorsOrigin(
+  origins: string | undefined,
+): boolean | string | string[] {
+  const normalized = origins?.trim();
+
+  if (!normalized) {
+    return true;
+  }
+
+  const list = normalized
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  if (list.length === 1) {
+    return list[0];
+  }
+
+  return list;
+}

--- a/libs/koala-nest/src/domain/dtos/pagination.dto.ts
+++ b/libs/koala-nest/src/domain/dtos/pagination.dto.ts
@@ -1,6 +1,61 @@
 import { QUERY_FILTER_PARAMS } from '@/core/constants/query-params';
 import { AutoMap } from '@/core/tools/mapping';
 import type { QueryDirectionType } from '@/core/types';
+import type {
+  FindOptionsOrder,
+  ObjectLiteral,
+  SelectQueryBuilder,
+} from 'typeorm';
+
+type OrderDirection = 'ASC' | 'DESC';
+
+function normalizeDirection(
+  direction?: QueryDirectionType | string,
+): OrderDirection {
+  return String(direction ?? 'asc').toLowerCase() === 'desc' ? 'DESC' : 'ASC';
+}
+
+function flattenOrderBy(
+  order: Record<string, unknown>,
+  prefix = '',
+): Array<{ path: string; direction: OrderDirection }> {
+  const entries: Array<{ path: string; direction: OrderDirection }> = [];
+
+  for (const [key, value] of Object.entries(order)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (typeof value === 'string') {
+      entries.push({ path, direction: normalizeDirection(value) });
+      continue;
+    }
+
+    if (value && typeof value === 'object') {
+      entries.push(...flattenOrderBy(value as Record<string, unknown>, path));
+    }
+  }
+
+  return entries;
+}
+
+function normalizeFindOptionsOrder(
+  order: Record<string, unknown>,
+): FindOptionsOrder<ObjectLiteral> {
+  const normalized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(order)) {
+    if (typeof value === 'string') {
+      normalized[key] = normalizeDirection(value);
+    } else if (value && typeof value === 'object') {
+      normalized[key] = normalizeFindOptionsOrder(
+        value as Record<string, unknown>,
+      );
+    } else {
+      normalized[key] = value;
+    }
+  }
+
+  return normalized as FindOptionsOrder<ObjectLiteral>;
+}
 
 export class PaginationDto {
   @AutoMap()
@@ -19,17 +74,47 @@ export class PaginationDto {
     return (this.limit ?? 0) * (this.page ?? QUERY_FILTER_PARAMS.page);
   }
 
-  generateOrderBy() {
+  generateOrderBy(): Record<string, unknown> | undefined {
     if (this.orderBy) {
       const orderByField = this.orderBy.split('.');
       return orderByField.reduceRight(
         (acc, item, index) => ({
           [item]: index === orderByField.length - 1 ? this.direction : acc,
         }),
-        {},
+        {} as Record<string, unknown>,
       );
     }
 
     return undefined;
+  }
+
+  toFindOptionsOrder(): FindOptionsOrder<ObjectLiteral> | undefined {
+    const order = this.generateOrderBy();
+
+    if (!order) {
+      return undefined;
+    }
+
+    return normalizeFindOptionsOrder(order);
+  }
+
+  applyQueryBuilderPagination<T extends ObjectLiteral>(
+    qb: SelectQueryBuilder<T>,
+    alias: string,
+  ): SelectQueryBuilder<T> {
+    const order = this.generateOrderBy();
+
+    if (order) {
+      for (const { path, direction } of flattenOrderBy(order)) {
+        const sortPath = path.includes('.') ? path : `${alias}.${path}`;
+        qb.addOrderBy(sortPath, direction);
+      }
+    }
+
+    return qb.skip(this.skip()).take(this.limit);
+  }
+
+  static from<T extends PaginationDto>(this: new () => T, props: Partial<T>): T {
+    return Object.assign(new this(), props);
   }
 }

--- a/libs/koala-nest/src/domain/dtos/person-query.dto.ts
+++ b/libs/koala-nest/src/domain/dtos/person-query.dto.ts
@@ -7,4 +7,12 @@ export class PersonQueryDto extends PaginationDto {
 
   @AutoMap()
   active?: boolean;
+
+  override generateOrderBy() {
+    if (this.orderBy) {
+      return super.generateOrderBy();
+    }
+
+    return { id: 'asc' };
+  }
 }

--- a/libs/koala-nest/src/domain/entities/person/person.ts
+++ b/libs/koala-nest/src/domain/entities/person/person.ts
@@ -27,7 +27,6 @@ export class Person extends EntityBase<Person> {
 
   @OneToOne(() => PersonAddress, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @JoinColumn()
@@ -36,7 +35,6 @@ export class Person extends EntityBase<Person> {
 
   @OneToMany(() => PersonContact, (contact) => contact.person, {
     cascade: true,
-    eager: true,
     onDelete: 'CASCADE',
   })
   @AutoMap({ type: () => PersonContact })

--- a/libs/koala-nest/src/host/bootstrap/apply-http-middleware.ts
+++ b/libs/koala-nest/src/host/bootstrap/apply-http-middleware.ts
@@ -1,0 +1,22 @@
+import { createRateLimitMiddleware } from '@/core/http/rate-limit.middleware';
+import { resolveCorsOrigin } from '@/core/utils/resolve-cors-origins';
+import { EnvService } from '@/infra/common/env.service';
+import type { INestApplication } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
+
+export function applyHttpMiddleware(app: INestApplication) {
+  const env = app.get(EnvService);
+
+  app.use(cookieParser());
+  app.use(
+    createRateLimitMiddleware({
+      windowMs: env.get('RATE_LIMIT_WINDOW_MS'),
+      maxRequests: env.get('RATE_LIMIT_MAX'),
+    }),
+  );
+  app.enableCors({
+    credentials: true,
+    origin: resolveCorsOrigin(env.get('CORS_ORIGINS')),
+    optionsSuccessStatus: 200,
+  });
+}

--- a/libs/koala-nest/src/host/main.ts
+++ b/libs/koala-nest/src/host/main.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 
+import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';
+import { resolveApiHost } from '@/core/utils/resolve-api-host';
 import { NestFactory } from '@nestjs/core';
-import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { defineDocumentation } from './open-api/define-documentation';
 import { ErrorsFilter } from './filters/errors.filter';
@@ -13,13 +14,7 @@ import { ILoggingService } from '@/domain/common/ilogging.service';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.use(cookieParser());
-
-  app.enableCors({
-    credentials: true,
-    origin: true,
-    optionsSuccessStatus: 200,
-  });
+  applyHttpMiddleware(app);
 
   await defineDocumentation(app);
 
@@ -32,12 +27,17 @@ async function bootstrap() {
     await app.resolve(ProfilesGuard),
   );
 
-  await app.listen(process.env.PORT || 3000);
+  const port = Number(process.env.PORT) || 3000;
+  const bindHost = process.env.HOST ?? '0.0.0.0';
+  const publicHost = resolveApiHost(process.env.API_HOST, port);
 
-  console.log(`Server is running on port ${process.env.PORT || 3000}`);
-  console.log(
-    `Documentation is available at http://localhost:${process.env.PORT || 3000}/doc`,
-  );
+  await app.listen(port, bindHost);
+
+  console.log(`Server is running on ${publicHost}`);
+  console.log(`Documentation is available at ${publicHost}/doc`);
 }
 
-bootstrap();
+bootstrap().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/libs/koala-nest/src/infra/common/redis-cache.service.ts
+++ b/libs/koala-nest/src/infra/common/redis-cache.service.ts
@@ -59,11 +59,22 @@ export class RedisCacheService implements ICacheService {
 
   async invalidateByPrefix(prefix: string): Promise<void> {
     const pattern = `${this.buildKey(prefix)}*`;
-    const keys = await this.client.keys(pattern);
+    let cursor = '0';
 
-    if (keys.length > 0) {
-      await this.client.del(...keys);
-    }
+    do {
+      const [nextCursor, keys] = await this.client.scan(
+        cursor,
+        'MATCH',
+        pattern,
+        'COUNT',
+        100,
+      );
+      cursor = nextCursor;
+
+      if (keys.length > 0) {
+        await this.client.del(...keys);
+      }
+    } while (cursor !== '0');
   }
 
   onModuleDestroy() {

--- a/libs/koala-nest/src/infra/repositories/person.repository.ts
+++ b/libs/koala-nest/src/infra/repositories/person.repository.ts
@@ -30,18 +30,18 @@ export class PersonRepository
     return this.repository
       .findAndCount({
         where,
-        order: query.generateOrderBy(),
+        order: query.toFindOptionsOrder(),
         skip: query.skip(),
         take: query.limit,
       })
       .then(([items, count]) => ({
-        items,
+        items: this.normalizeEntities(items),
         count,
       }));
   }
 
   findById(id: number): Promise<Person | null> {
-    return this.repository.findOne({
+    return this.findOneNormalized({
       where: { id },
       relations: { address: true, contacts: true },
     });

--- a/libs/koala-nest/src/infra/repositories/repository.base.ts
+++ b/libs/koala-nest/src/infra/repositories/repository.base.ts
@@ -1,4 +1,27 @@
-import { DataSource, EntityTarget, ObjectLiteral, Repository } from 'typeorm';
+import { initializeUndefinedArrayProps } from '@/core/utils/initialize-undefined-array-props';
+import type { Type } from '@nestjs/common';
+import {
+  DataSource,
+  EntityTarget,
+  FindManyOptions,
+  FindOneOptions,
+  ObjectLiteral,
+  Repository,
+} from 'typeorm';
+
+function getLoadedRelationKeys(
+  relations?: FindOneOptions<ObjectLiteral>['relations'],
+): string[] {
+  if (!relations) {
+    return [];
+  }
+
+  if (Array.isArray(relations)) {
+    return relations.map(String);
+  }
+
+  return Object.keys(relations);
+}
 
 export class RepositoryBase<T extends ObjectLiteral> {
   protected readonly repository: Repository<T>;
@@ -8,6 +31,52 @@ export class RepositoryBase<T extends ObjectLiteral> {
     protected readonly entity: EntityTarget<T>,
   ) {
     this.repository = this.dataSource.getRepository<T>(entity);
+  }
+
+  protected normalizeEntity<E extends ObjectLiteral>(
+    entity: E,
+    loadedRelationKeys: string[] = [],
+  ): E {
+    if (loadedRelationKeys.length > 0) {
+      initializeUndefinedArrayProps(
+        entity as Record<string, unknown>,
+        this.getEntityType(),
+        loadedRelationKeys,
+      );
+    }
+
+    return entity;
+  }
+
+  protected normalizeEntities<E extends ObjectLiteral>(
+    entities: E[],
+    loadedRelationKeys: string[] = [],
+  ): E[] {
+    return entities.map((entity) =>
+      this.normalizeEntity(entity, loadedRelationKeys),
+    );
+  }
+
+  protected getEntityType(): Type<unknown> {
+    return this.entity as Type<unknown>;
+  }
+
+  protected findOneNormalized(options: FindOneOptions<T>) {
+    const loadedRelationKeys = getLoadedRelationKeys(options.relations);
+
+    return this.repository
+      .findOne(options)
+      .then((entity) =>
+        entity ? this.normalizeEntity(entity, loadedRelationKeys) : null,
+      );
+  }
+
+  protected findNormalized(options: FindManyOptions<T>) {
+    const loadedRelationKeys = getLoadedRelationKeys(options.relations);
+
+    return this.repository
+      .find(options)
+      .then((entities) => this.normalizeEntities(entities, loadedRelationKeys));
   }
 
   save(entity: T) {

--- a/libs/koala-nest/src/test/application/delete-inactive.job.spec.ts
+++ b/libs/koala-nest/src/test/application/delete-inactive.job.spec.ts
@@ -1,19 +1,32 @@
+import { describe, expect, it } from 'bun:test';
 import { DeleteInactiveJob } from '@/application/person/jobs/cron/delete-inactive.job';
 import { DeletePersonHandler } from '@/application/person/delete/delete-person.handler';
-import { ReadManyPersonHandler } from '@/application/person/read-many/read-many-person.handler';
+import { Person } from '@/domain/entities/person/person';
+import type { IPersonRepository } from '@/domain/repositories/iperson.repository';
 import { FakeLoggingService } from '@/test/services/fake-logging.service';
 import { FakeRedLockService } from '@/test/services/fake-red-lock.service';
 
 describe('DeleteInactiveJob', () => {
-  it('remove pessoas inativas retornadas pela listagem', async () => {
+  it('remove todas as páginas de pessoas inativas', async () => {
     const deletedIds: number[] = [];
+    const inactivePeople = Array.from({ length: 35 }, (_, index) => {
+      const person = new Person();
+      person.id = index + 1;
+      person.name = `Inactive ${index + 1}`;
+      person.active = false;
+      return person;
+    });
 
-    const readManyPerson = {
-      handle: async () => ({
-        items: [{ id: 1, name: 'Inactive', active: false }],
-        count: 1,
-      }),
-    } as unknown as ReadManyPersonHandler;
+    const repository = {
+      findMany: async (query: { page?: number; limit?: number }) => {
+        const currentPage = query.page ?? 0;
+        const limit = query.limit ?? 30;
+        const start = currentPage * limit;
+        const items = inactivePeople.slice(start, start + limit);
+
+        return { items, count: inactivePeople.length };
+      },
+    } as unknown as IPersonRepository;
 
     const deletePerson = {
       handle: async (id: number) => {
@@ -24,12 +37,12 @@ describe('DeleteInactiveJob', () => {
     const job = new DeleteInactiveJob(
       new FakeRedLockService(),
       new FakeLoggingService(),
-      readManyPerson,
+      repository,
       deletePerson,
     );
 
     await job['run']();
 
-    expect(deletedIds).toEqual([1]);
+    expect(deletedIds).toHaveLength(35);
   });
 });

--- a/libs/koala-nest/src/test/application/update-person.handler.spec.ts
+++ b/libs/koala-nest/src/test/application/update-person.handler.spec.ts
@@ -58,6 +58,48 @@ describe('UpdatePersonHandler', () => {
     expect(cache.invalidateByPrefixCalls).toEqual([PERSON_LIST_CACHE_PREFIX]);
   });
 
+  it('remove contatos ausentes do payload (órfãos via TypeORM)', async () => {
+    const cache = new CacheStub();
+    const keptContact = PersonContact.from({
+      id: 10,
+      contact: 'keep@example.com',
+      person: undefined as unknown as Person,
+    });
+    const removedContact = PersonContact.from({
+      id: 11,
+      contact: 'remove@example.com',
+      person: undefined as unknown as Person,
+    });
+
+    const person = Person.from({
+      id: 1,
+      name: 'Jane',
+      active: true,
+      address: PersonAddress.from({ id: 5, address: 'Street' }),
+      contacts: [keptContact, removedContact],
+    });
+    keptContact.person = person;
+    removedContact.person = person;
+
+    const repository = {
+      findById: async () => person,
+      save: async (entity: Person) => entity,
+    } as unknown as IPersonRepository;
+
+    const handler = new UpdatePersonHandler(repository, cache);
+
+    await handler.handle({
+      id: 1,
+      name: 'Jane',
+      address: { id: 5, address: 'Street' },
+      contacts: [{ id: 10, contact: 'keep@example.com' }],
+    });
+
+    expect(person.contacts).toHaveLength(1);
+    expect(person.contacts[0].id).toBe(10);
+    expect(person.contacts[0].contact).toBe('keep@example.com');
+  });
+
   it('lança NotFoundException quando a pessoa não existe', async () => {
     const repository = {
       findById: async () => null,

--- a/libs/koala-nest/src/test/core/cron-expression-to-boolean.spec.ts
+++ b/libs/koala-nest/src/test/core/cron-expression-to-boolean.spec.ts
@@ -1,7 +1,26 @@
 /// <reference types="bun-types/test-globals" />
 
-import { cronExpressionToBoolean } from '@/core/utils/cron-expression-to-boolean';
+import {
+  cronExpressionToBoolean,
+  getCronExecutionKey,
+} from '@/core/utils/cron-expression-to-boolean';
 import { describe, expect, it } from 'bun:test';
+
+describe('getCronExecutionKey', () => {
+  it('retorna ISO do tick quando o instante coincide com a expressão', () => {
+    const at = new Date(2024, 5, 12, 12, 0, 0, 1);
+
+    expect(getCronExecutionKey('0 0 12 * * *', at)).toBe(
+      new Date(2024, 5, 12, 12, 0, 0).toISOString(),
+    );
+  });
+
+  it('retorna null quando o instante não coincide', () => {
+    const at = new Date(2024, 5, 12, 12, 0, 1);
+
+    expect(getCronExecutionKey('0 0 12 * * *', at)).toBeNull();
+  });
+});
 
 describe('cronExpressionToBoolean', () => {
   it('retorna true quando o instante atual coincide com o tick da expressão', () => {

--- a/libs/koala-nest/src/test/core/env.spec.ts
+++ b/libs/koala-nest/src/test/core/env.spec.ts
@@ -3,6 +3,15 @@ import { parseOAuth2ProviderEnv } from '@/core/auth/parse-oauth2-provider-env';
 import { envSchema, validateEnvConfig } from '@/core/env';
 
 describe('envSchema', () => {
+  it('define HOST com default 0.0.0.0 para bind em container', () => {
+    const env = envSchema.parse({
+      NODE_ENV: 'test',
+      DATABASE_URL: 'postgres://localhost/test',
+    });
+
+    expect(env.HOST).toBe('0.0.0.0');
+  });
+
   it('interpreta CRON_JOBS_ENABLED=false como desabilitado', () => {
     const env = envSchema.parse({
       NODE_ENV: 'test',
@@ -11,6 +20,16 @@ describe('envSchema', () => {
     });
 
     expect(env.CRON_JOBS_ENABLED).toBe(false);
+  });
+
+  it('define rate limit desabilitado por padrão', () => {
+    const env = envSchema.parse({
+      NODE_ENV: 'test',
+      DATABASE_URL: 'postgres://localhost/test',
+    });
+
+    expect(env.RATE_LIMIT_MAX).toBe(0);
+    expect(env.RATE_LIMIT_WINDOW_MS).toBe(60_000);
   });
 });
 

--- a/libs/koala-nest/src/test/core/http/rate-limit.middleware.spec.ts
+++ b/libs/koala-nest/src/test/core/http/rate-limit.middleware.spec.ts
@@ -1,0 +1,62 @@
+/// <reference types="bun-types/test-globals" />
+
+import { createRateLimitMiddleware } from '@/core/http/rate-limit.middleware';
+import { describe, expect, it } from 'bun:test';
+
+function createMockResponse() {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response;
+}
+
+describe('createRateLimitMiddleware', () => {
+  it('permite requisições quando rate limit está desabilitado', () => {
+    const middleware = createRateLimitMiddleware({
+      windowMs: 60_000,
+      maxRequests: 0,
+    });
+    let called = false;
+    const next = () => {
+      called = true;
+    };
+
+    middleware(
+      { ip: '127.0.0.1' } as never,
+      createMockResponse() as never,
+      next,
+    );
+
+    expect(called).toBe(true);
+  });
+
+  it('bloqueia requisições após atingir maxRequests', () => {
+    const middleware = createRateLimitMiddleware({
+      windowMs: 60_000,
+      maxRequests: 2,
+    });
+    const req = { ip: '127.0.0.1' } as never;
+    const next = () => {};
+
+    middleware(req, createMockResponse() as never, next);
+    middleware(req, createMockResponse() as never, next);
+    const blockedResponse = createMockResponse();
+
+    middleware(req, blockedResponse as never, next);
+
+    expect(blockedResponse.statusCode).toBe(429);
+    expect(blockedResponse.body).toMatchObject({
+      statusCode: 429,
+    });
+  });
+});

--- a/libs/koala-nest/src/test/core/initialize-undefined-array-props.spec.ts
+++ b/libs/koala-nest/src/test/core/initialize-undefined-array-props.spec.ts
@@ -1,0 +1,63 @@
+/// <reference types="bun-types/test-globals" />
+
+import { initializeUndefinedArrayProps } from '@/core/utils/initialize-undefined-array-props';
+import { AutoMap } from '@/core/tools/mapping';
+import { MappingStore } from '@/core/tools/mapping/mapping-store';
+import { describe, expect, it } from 'bun:test';
+
+class ChildItem {
+  @AutoMap()
+  name!: string;
+}
+
+class EntityWithArrays {
+  @AutoMap()
+  title!: string;
+
+  @AutoMap({ type: () => ChildItem })
+  children!: ChildItem[];
+}
+
+describe('initializeUndefinedArrayProps', () => {
+  it('inicializa props de array mapeadas como [] quando undefined', () => {
+    const target = { title: 'Test' } as Record<string, unknown>;
+
+    initializeUndefinedArrayProps(target, EntityWithArrays);
+
+    expect(target.children).toEqual([]);
+  });
+
+  it('respeita onlyProps quando informado', () => {
+    const target = { title: 'Test' } as Record<string, unknown>;
+
+    initializeUndefinedArrayProps(target, EntityWithArrays, ['title']);
+
+    expect(target.children).toBeUndefined();
+  });
+
+  it('não sobrescreve array já definido', () => {
+    const existing: ChildItem[] = [];
+    const target = { title: 'Test', children: existing } as Record<
+      string,
+      unknown
+    >;
+
+    initializeUndefinedArrayProps(target, EntityWithArrays);
+
+    expect(target.children).toBe(existing);
+  });
+
+  it('detecta arrays via metadata composition:type', () => {
+    class DtoWithExplicitArray {
+      @AutoMap({ type: () => ChildItem, isArray: true })
+      items!: ChildItem[];
+    }
+
+    MappingStore.getAllProps(DtoWithExplicitArray);
+
+    const target = {} as Record<string, unknown>;
+    initializeUndefinedArrayProps(target, DtoWithExplicitArray);
+
+    expect(target.items).toEqual([]);
+  });
+});

--- a/libs/koala-nest/src/test/core/mapping.spec.ts
+++ b/libs/koala-nest/src/test/core/mapping.spec.ts
@@ -104,6 +104,21 @@ describe('AutoMapper', () => {
     expect(person.contacts[0].contact).toBe(personRequest.contacts[0].contact);
   });
 
+  it('inicializa arrays undefined no destino após o map', () => {
+    createMap(PersonRequest, Person);
+
+    const personRequest = PersonRequest.from({
+      name: 'John Doe',
+      address: {
+        address: '123 Main St',
+      },
+    });
+
+    const person = AutoMapper.map(personRequest, PersonRequest, Person);
+
+    expect(person.contacts).toEqual([]);
+  });
+
   it('should apply forMember custom mappings', () => {
     class SourceRequest {
       @AutoMap()

--- a/libs/koala-nest/src/test/core/pagination-typeorm.spec.ts
+++ b/libs/koala-nest/src/test/core/pagination-typeorm.spec.ts
@@ -1,0 +1,74 @@
+/// <reference types="bun-types/test-globals" />
+
+import { PaginationDto } from '@/domain/dtos/pagination.dto';
+import { PersonQueryDto } from '@/domain/dtos/person-query.dto';
+import { describe, expect, it } from 'bun:test';
+
+describe('PaginationDto TypeORM', () => {
+  it('toFindOptionsOrder normaliza direction para ASC/DESC', () => {
+    const query = PaginationDto.from({ orderBy: 'name', direction: 'desc' });
+
+    expect(query.toFindOptionsOrder()).toEqual({ name: 'DESC' });
+  });
+
+  it('toFindOptionsOrder suporta ordenação aninhada', () => {
+    const query = PaginationDto.from({
+      orderBy: 'address.city',
+      direction: 'asc',
+    });
+
+    expect(query.toFindOptionsOrder()).toEqual({
+      address: { city: 'ASC' },
+    });
+  });
+
+  it('applyQueryBuilderPagination aplica order, skip e take', () => {
+    const qb = {
+      expressionMap: {
+        orderBys: {} as Record<string, string>,
+        skip: 0,
+        take: 0,
+      },
+      addOrderBy(path: string, direction: string) {
+        this.expressionMap.orderBys[path] = direction;
+        return this;
+      },
+      skip(value: number) {
+        this.expressionMap.skip = value;
+        return this;
+      },
+      take(value: number) {
+        this.expressionMap.take = value;
+        return this;
+      },
+    };
+    const query = PaginationDto.from({
+      page: 1,
+      limit: 10,
+      orderBy: 'name',
+      direction: 'desc',
+    });
+
+    const result = query.applyQueryBuilderPagination(qb as never, 'entity');
+
+    expect(result.expressionMap.orderBys).toEqual({ 'entity.name': 'DESC' });
+    expect(result.expressionMap.skip).toBe(10);
+    expect(result.expressionMap.take).toBe(10);
+  });
+});
+
+describe('PersonQueryDto default sort', () => {
+  it('usa id asc quando orderBy não é informado', () => {
+    const query = PersonQueryDto.from({ name: 'Jane' });
+
+    expect(query.generateOrderBy()).toEqual({ id: 'asc' });
+    expect(query.toFindOptionsOrder()).toEqual({ id: 'ASC' });
+  });
+
+  it('delega para PaginationDto quando orderBy é informado', () => {
+    const query = PersonQueryDto.from({ orderBy: 'name', direction: 'desc' });
+
+    expect(query.generateOrderBy()).toEqual({ name: 'desc' });
+    expect(query.toFindOptionsOrder()).toEqual({ name: 'DESC' });
+  });
+});

--- a/libs/koala-nest/src/test/core/resolve-cors-origins.spec.ts
+++ b/libs/koala-nest/src/test/core/resolve-cors-origins.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { resolveCorsOrigin } from '@/core/utils/resolve-cors-origins';
+
+describe('resolveCorsOrigin', () => {
+  it('permite qualquer origin quando CORS_ORIGINS não está definido', () => {
+    expect(resolveCorsOrigin(undefined)).toBe(true);
+    expect(resolveCorsOrigin('')).toBe(true);
+    expect(resolveCorsOrigin('   ')).toBe(true);
+  });
+
+  it('aceita lista de origens separadas por vírgula', () => {
+    expect(
+      resolveCorsOrigin('http://localhost:4200, https://app.example.com'),
+    ).toEqual(['http://localhost:4200', 'https://app.example.com']);
+  });
+
+  it('retorna string única quando há uma origem', () => {
+    expect(resolveCorsOrigin('https://app.example.com')).toBe(
+      'https://app.example.com',
+    );
+  });
+});

--- a/libs/koala-nest/src/test/core/sync-improvements.spec.ts
+++ b/libs/koala-nest/src/test/core/sync-improvements.spec.ts
@@ -1,0 +1,39 @@
+/// <reference types="bun-types/test-globals" />
+
+import { ListResponseBase } from '@/core/common/list-response.base';
+import { PaginationDto } from '@/domain/dtos/pagination.dto';
+import { describe, expect, it } from 'bun:test';
+
+class QueryPersonDto extends PaginationDto {
+  name?: string;
+}
+
+class PersonListItem {
+  id!: number;
+  name!: string;
+}
+
+class PersonListResponse extends ListResponseBase<PersonListItem> {}
+
+describe('PaginationDto.from', () => {
+  it('cria instância com props parciais herdando defaults', () => {
+    const query = QueryPersonDto.from({ name: 'Jane', limit: 50 });
+
+    expect(query).toBeInstanceOf(QueryPersonDto);
+    expect(query.name).toBe('Jane');
+    expect(query.limit).toBe(50);
+    expect(query.page).toBe(0);
+  });
+});
+
+describe('ListResponseBase.from', () => {
+  it('cria resposta paginada via ObjectClass.from', () => {
+    const response = PersonListResponse.from({
+      items: [{ id: 1, name: 'Jane' }],
+      count: 1,
+    });
+
+    expect(response.items).toHaveLength(1);
+    expect(response.count).toBe(1);
+  });
+});

--- a/libs/koala-nest/src/test/host/controllers/person/lazy-loading.e2e.spec.ts
+++ b/libs/koala-nest/src/test/host/controllers/person/lazy-loading.e2e.spec.ts
@@ -10,13 +10,11 @@ import { IPersonRepository } from '@/domain/repositories/iperson.repository';
 import { Test, TestingModule } from '@nestjs/testing';
 
 /**
- * Testes E2E do RepositoryBase - Lazy Loading
- *
- * Valida o carregamento efetivo de relacionamentos em diferentes cenários:
- * - findById: carrega recursivamente todos os relacionamentos
- * - findMany: carrega com otimização para listas
+ * Valida carregamento explícito de relacionamentos no repositório.
+ * - findById: relations { address, contacts }
+ * - findMany: sem relations (listagem leve; contacts normalizado como [])
  */
-describe('RepositoryBase - Lazy Loading (E2E)', () => {
+describe('PersonRepository - Relations (E2E)', () => {
   let moduleRef: TestingModule;
 
   beforeAll(async () => {
@@ -25,8 +23,8 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
     }).compile();
   });
 
-  describe('findById - Carregamento de Relacionamentos', () => {
-    it('should load person with all relationships using findById', async () => {
+  describe('findById - relations explícitas', () => {
+    it('should load person with address and contacts using findById', async () => {
       const createHandler = moduleRef.get(CreatePersonHandler);
       const created = await createHandler.handle({
         name: 'João Silva',
@@ -53,30 +51,10 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
         'joao@example.com',
       ]);
     });
-
-    it('should have all relationships loaded and accessible', async () => {
-      const createHandler = moduleRef.get(CreatePersonHandler);
-      const created = await createHandler.handle({
-        name: 'Test Person',
-        contacts: [{ contact: 'test@example.com' }],
-        address: {
-          address: 'Test Address',
-        },
-      });
-
-      const readHandler = moduleRef.get(ReadPersonHandler);
-      const person = await readHandler.handle(created.id);
-
-      expect(person.id).toBe(created.id);
-      expect(person.address).toBeDefined();
-      expect(person.address.address).toBeDefined();
-      expect(person.contacts).toBeDefined();
-      expect(person.contacts.length).toBeGreaterThan(0);
-    });
   });
 
-  describe('findMany - Carregamento Otimizado para Listas', () => {
-    it('should load persons with relationships in findMany', async () => {
+  describe('findMany - listagem sem relations', () => {
+    it('should return persons without loading relations in findMany', async () => {
       const createHandler = moduleRef.get(CreatePersonHandler);
 
       for (let i = 0; i < 2; i++) {
@@ -90,10 +68,7 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
       }
 
       const repository = moduleRef.get(IPersonRepository);
-      const query = Object.assign(new PersonQueryDto(), {
-        limit: 100,
-        page: 0,
-      });
+      const query = PersonQueryDto.from({ limit: 100, page: 0 });
       const { items } = await repository.findMany(query);
 
       expect(items.length).toBeGreaterThan(0);
@@ -101,11 +76,11 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
       const person = items[0];
       expect(person.id).toBeDefined();
       expect(person.name).toBeDefined();
-      expect(person.address).toBeDefined();
-      expect(person.contacts).toBeDefined();
+      expect(person.address).toBeUndefined();
+      expect(person.contacts ?? []).toHaveLength(0);
     });
 
-    it('should load multiple persons efficiently', async () => {
+    it('should list via handler without requiring relations on entities', async () => {
       const createHandler = moduleRef.get(CreatePersonHandler);
 
       const createdIds: number[] = [];
@@ -120,8 +95,6 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
         createdIds.push(result.id);
       }
 
-      expect(createdIds.length).toBe(3);
-
       const readManyHandler = moduleRef.get(ReadManyPersonHandler);
       const result = await readManyHandler.handle(new ReadManyPersonRequest());
 
@@ -132,23 +105,15 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
       createdIds.forEach((id) => {
         expect(returnedIds).toContain(id);
       });
-
-      result.items.forEach((person) => {
-        expect(person.id).toBeDefined();
-        expect(person.name).toBeDefined();
-      });
     });
   });
 
-  describe('Comparação entre findById e findMany', () => {
-    it('should load relationships in both methods', async () => {
+  describe('findById vs findMany', () => {
+    it('findById carrega relations; findMany retorna entidade leve', async () => {
       const createHandler = moduleRef.get(CreatePersonHandler);
       const created = await createHandler.handle({
         name: 'Comparação Test',
-        contacts: [
-          { contact: 'first@example.com' },
-          { contact: 'second@example.com' },
-        ],
+        contacts: [{ contact: 'first@example.com' }],
         address: {
           address: 'Rua Comparação, 789',
         },
@@ -158,24 +123,19 @@ describe('RepositoryBase - Lazy Loading (E2E)', () => {
       const personFromFindById = await readHandler.handle(created.id);
 
       const repository = moduleRef.get(IPersonRepository);
-      const query = Object.assign(new PersonQueryDto(), {
-        limit: 100,
-        page: 0,
-      });
-      const { items } = await repository.findMany(query);
+      const { items } = await repository.findMany(
+        PersonQueryDto.from({ limit: 100, page: 0 }),
+      );
       const personFromFindMany = items.find((p) => p.id === created.id);
 
       expect(personFromFindMany).toBeDefined();
       expect(personFromFindById.id).toBe(personFromFindMany!.id);
       expect(personFromFindById.name).toBe(personFromFindMany!.name);
-
       expect(personFromFindById.address).toBeDefined();
       expect(personFromFindById.contacts).toBeDefined();
       expect(personFromFindById.contacts.length).toBeGreaterThan(0);
-
-      expect(personFromFindMany?.address).toBeDefined();
-      expect(personFromFindMany?.contacts).toBeDefined();
-      expect(personFromFindMany?.contacts.length).toBeGreaterThan(0);
+      expect(personFromFindMany?.address).toBeUndefined();
+      expect(personFromFindMany?.contacts ?? []).toHaveLength(0);
     });
   });
 });

--- a/libs/koala-nest/src/test/infra/redis-cache.service.spec.ts
+++ b/libs/koala-nest/src/test/infra/redis-cache.service.spec.ts
@@ -35,6 +35,14 @@ class RedisStub {
     );
   }
 
+  scan(cursor: string, ...args: unknown[]) {
+    const pattern = String(args[1] ?? '');
+    const prefix = pattern.replace(/\*$/, '');
+    const keys = [...this.store.keys()].filter((key) => key.startsWith(prefix));
+
+    return Promise.resolve(['0', keys]);
+  }
+
   disconnect() {}
 }
 

--- a/libs/koala-nest/src/test/utils/configure-test-app.ts
+++ b/libs/koala-nest/src/test/utils/configure-test-app.ts
@@ -1,17 +1,11 @@
+import { applyHttpMiddleware } from '@/host/bootstrap/apply-http-middleware';
 import { ErrorsFilter } from '@/host/filters/errors.filter';
 import { ILoggingService } from '@/domain/common/ilogging.service';
 import { INestApplication } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
-import cookieParser from 'cookie-parser';
 
 export function setupTestApp(app: INestApplication) {
-  app.use(cookieParser());
-
-  app.enableCors({
-    credentials: true,
-    origin: true,
-    optionsSuccessStatus: 200,
-  });
+  applyHttpMiddleware(app);
 
   const { httpAdapter } = app.get(HttpAdapterHost);
   const loggingService = app.get(ILoggingService);

--- a/libs/koala-nest/src/test/utils/in-memory-base.repository.ts
+++ b/libs/koala-nest/src/test/utils/in-memory-base.repository.ts
@@ -1,0 +1,80 @@
+import { PaginationDto } from '@/domain/dtos/pagination.dto';
+import { ListResponseBase } from '@/core/common/list-response.base';
+import { QUERY_FILTER_PARAMS } from '@/core/constants/query-params';
+import { KlArray } from '@koalarx/utils/KlArray';
+import { randomUUID } from 'node:crypto';
+
+export abstract class InMemoryBaseRepository<
+  TClass extends { id?: number | string | null },
+> {
+  protected items: TClass[] = [];
+
+  constructor(private readonly typeId: 'number' | 'string' = 'number') {}
+
+  protected async findById(id: number | string) {
+    return this.items.find((item) => item.id === id) ?? null;
+  }
+
+  protected async findMany<T extends PaginationDto>(
+    query: T,
+    predicate?: (value: TClass, index: number, array: TClass[]) => unknown,
+  ) {
+    const page = query.page ?? QUERY_FILTER_PARAMS.page;
+    const limit = query.limit ?? QUERY_FILTER_PARAMS.limit;
+
+    return new KlArray(predicate ? this.items.filter(predicate) : this.items)
+      .orderBy(query.orderBy ?? '', query.direction)
+      .slice(page * limit, (page + 1) * limit);
+  }
+
+  protected async findManyAndCount<T extends PaginationDto>(
+    query: T,
+    predicate?: (value: TClass, index: number, array: TClass[]) => unknown,
+  ): Promise<ListResponseBase<TClass>> {
+    const filtered = predicate ? this.items.filter(predicate) : this.items;
+    const page = query.page ?? QUERY_FILTER_PARAMS.page;
+    const limit = query.limit ?? QUERY_FILTER_PARAMS.limit;
+    const items = new KlArray(filtered)
+      .orderBy(query.orderBy ?? '', query.direction)
+      .slice(page * limit, (page + 1) * limit);
+
+    return ListResponseBase.from({ items, count: filtered.length });
+  }
+
+  protected async saveChanges(
+    item: TClass,
+    updateWhere?: (item: TClass) => boolean,
+  ) {
+    if (!item.id) {
+      const id = this.typeId === 'number' ? this.getNewId() : randomUUID();
+      (item as { id: number | string }).id = id;
+      this.items.push(item);
+      return { id };
+    }
+
+    const predicate = updateWhere ?? ((stored) => stored.id === item.id);
+    const itemIndex = this.items.findIndex(predicate);
+
+    if (itemIndex > -1) {
+      this.items[itemIndex] = item;
+    } else {
+      this.items.push(item);
+    }
+  }
+
+  protected async remove(
+    predicate: (value: TClass, index: number, obj: TClass[]) => unknown,
+  ) {
+    const itemIndex = this.items.findIndex(predicate);
+    if (itemIndex > -1) this.items.splice(itemIndex, 1);
+  }
+
+  private getNewId() {
+    if (this.typeId === 'number') {
+      const lastId = new KlArray(this.items).orderBy('id', 'desc')[0]?.id;
+      return lastId ? (lastId as number) + 1 : 1;
+    }
+
+    return randomUUID();
+  }
+}


### PR DESCRIPTION
## Summary
- Unifica bootstrap HTTP (`applyHttpMiddleware`) com CORS aberto configurável via `CORS_ORIGINS`, rate limit e cookies
- Corrige `DeleteInactiveJob` com paginação em lotes, Redis `SCAN` no cache e normalização segura de relations no `RepositoryBase`
- Remove APIs mortas (`mapInto`, `IComparableId`, rate-limit legado na CLI) e alinha Person com `eager: false` + relations explícitas
- Atualiza docs, checklist da CLI e cobertura de testes (unit + E2E)

## Test plan
- [x] `bun run test:unit` (CLI, koala-nest, docs)
- [x] `bun run test:koala-nest:e2e` (18 testes)

Made with [Cursor](https://cursor.com)