### PR TITLE
Enhance entity modeling documentation

### DIFF
--- a/libs/doc/markdown/en/core/reusable-bases.md
+++ b/libs/doc/markdown/en/core/reusable-bases.md
@@ -126,6 +126,18 @@ export class RepositoryBase<T extends ObjectLiteral> {
 }
 ```
 
+## Entity
+
+Mark domain entities with `@Entity` from `@/core/database/entity`. The decorator applies TypeORM's `@Entity` and registers the class in `DbContext.entities`:
+
+```typescript
+// src/core/database/entity.ts
+import { Entity } from '@/core/database/entity';
+
+@Entity('person')
+export class Person extends EntityBase<Person> {}
+```
+
 ## EntityBase
 
 Domain entities extend `EntityBase`, which in turn extends `ObjectClass`:

--- a/libs/doc/markdown/en/domain/entities.md
+++ b/libs/doc/markdown/en/domain/entities.md
@@ -4,18 +4,48 @@ slug: entities
 category: domain
 docKey: domain/entidades
 order: 1
-description: TypeORM entity modeling with EntityBase and the AutoMap decorator.
+description: Entity modeling with core Entity decorator, EntityBase, and AutoMap.
 ---
 
 # Entities
 
-Entities represent the domain model persisted in the database. They live in `src/domain/entities` and use TypeORM decorators combined with `@AutoMap()` for the mapping system.
+Entities represent the domain model persisted in the database. They live in `src/domain/entities`, use the core `@Entity` decorator (which wraps TypeORM), and combine other TypeORM decorators with `@AutoMap()` for the mapping system.
+
+## @Entity decorator
+
+Use `@Entity` from `@/core/database/entity` — **do not** import `Entity` from `typeorm`. Under the hood, the decorator applies TypeORM's `@Entity` and registers the class in `DbContext.entities` so `dataSourceFactory` can build the array automatically:
+
+```typescript
+// src/core/database/entity.ts
+import { Entity as TypeOrmEntity } from 'typeorm';
+import { DbContext } from './db-context';
+
+export function Entity(tableName: string) {
+  return function (target: Function) {
+    TypeOrmEntity(tableName)(target);
+    DbContext.entities.add(target);
+  };
+}
+```
+
+Column and relationship decorators (`Column`, `OneToMany`, `ManyToOne`, etc.) are still imported from `typeorm`.
 
 ## Main entity
 
 The `Person` entity demonstrates `OneToOne` and `OneToMany` relationships with cascade:
 
 ```typescript
+import { EntityBase } from '@/core/base/entity.base';
+import { Entity } from '@/core/database/entity';
+import { AutoMap } from '@/core/tools/mapping';
+import {
+  Column,
+  JoinColumn,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
 @Entity('person')
 export class Person extends EntityBase<Person> {
   @PrimaryGeneratedColumn()
@@ -95,18 +125,23 @@ This allows `AutoMapper` to resolve the target type when mapping each item in th
 
 ## DataSource registration
 
-All entities must be listed in the DataSource factory:
+`dataSourceFactory` reads entities registered automatically by the `@Entity` decorator:
 
 ```typescript
+import { DbContext } from '@/core/database/db-context';
+
 const dataSource = new DataSource({
   type: 'postgres',
   url: env.get('DATABASE_URL'),
-  entities: [Person, PersonAddress, PersonContact],
+  schema: env.get('DATABASE_SCHEMA'),
+  entities: Array.from(DbContext.entities.values()),
   invalidWhereValuesBehavior: {
     undefined: 'ignore',
   },
 });
 ```
+
+When you decorate a new entity with `@Entity`, it is already included in the runtime DataSource — no manual change to `dataSourceFactory` is required.
 
 The `invalidWhereValuesBehavior.undefined: 'ignore'` option prevents optional filters (`undefined`) from generating invalid clauses in TypeORM.
 
@@ -139,4 +174,4 @@ findMany(query: PersonQueryDto): Promise<ListResponse<Person>> {
 - Keep entities free of HTTP logic (no `@ApiProperty`).
 - Use `cascade` and `onDelete` according to the aggregate's business rules.
 - Persisted collections are **full state** on `save` — replace the list on update; missing items become orphans with `orphanedRowAction: 'delete'`.
-- Register new entities in `dataSourceFactory` and generate migrations after changes.
+- Use `@Entity` from `@/core/database/entity` and generate migrations after schema changes.

--- a/libs/doc/markdown/en/guides/person-crud-flow.md
+++ b/libs/doc/markdown/en/guides/person-crud-flow.md
@@ -47,9 +47,20 @@ src/
 
 ## 1. Model entities
 
-Define entities with TypeORM and `@AutoMap()`:
+Define entities with the core `@Entity` decorator and `@AutoMap()`:
 
 ```typescript
+import { EntityBase } from '@/core/base/entity.base';
+import { Entity } from '@/core/database/entity';
+import { AutoMap } from '@/core/tools/mapping';
+import {
+  Column,
+  JoinColumn,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
 @Entity('person')
 export class Person extends EntityBase<Person> {
   @PrimaryGeneratedColumn()
@@ -198,14 +209,9 @@ export class PersonModule {}
 
 Import `PersonModule` in `AppModule`.
 
-## 8. Register entities and generate migration
+## 8. Generate migration
 
-Add entities in `dataSourceFactory` (runtime) and generate the migration:
-
-```typescript
-// src/infra/database/data-source-factory.ts
-entities: [Person, PersonAddress, PersonContact],
-```
+With entities decorated using the core `@Entity`, `dataSourceFactory` already includes them via `DbContext`. Generate and apply the migration:
 
 ```bash
 bun run migration:generate
@@ -213,7 +219,7 @@ bun run migration:run
 bun run start:dev
 ```
 
-The migration generator (`migration-datasource.ts`) discovers entities in `src/domain/entities/` by glob — explicit registration in `dataSourceFactory` is required for the runtime server.
+The migration generator (`migration-datasource.ts`) discovers entities in `src/domain/entities/` by glob.
 
 Visit `http://localhost:3000/doc` to test endpoints interactively.
 
@@ -270,7 +276,7 @@ When creating a resource similar to Person, follow the steps in this guide in or
 
 1. **Domain** — entities, `I<Resource>Repository` contract, and query DTOs (if there is listing)
 2. **Application** — handlers, requests, responses, validators, and `<Resource>Mapper.createMap()` in `MappingProvider`
-3. **Infra** — concrete repository, provider in `RepositoryModule`, and entities in `dataSourceFactory`
+3. **Infra** — concrete repository and provider in `RepositoryModule`
 4. **Host** — `router.config.ts`, controllers, `<Resource>Module`, and import in `AppModule`
 5. **Migrations** — `migration:generate`, review the generated file, and `migration:run`
 

--- a/libs/doc/markdown/en/infra/database.md
+++ b/libs/doc/markdown/en/infra/database.md
@@ -31,13 +31,16 @@ export class DatabaseModule {}
 ## DataSource factory
 
 ```typescript
+import { DbContext } from '@/core/database/db-context';
+
 export const DATA_SOURCE_PROVIDER_TOKEN = 'DATA_SOURCE';
 
 export async function dataSourceFactory(env: EnvService) {
   const dataSource = new DataSource({
     type: 'postgres',
     url: env.get('DATABASE_URL'),
-    entities: [Person, PersonAddress, PersonContact],
+    schema: env.get('DATABASE_SCHEMA'),
+    entities: Array.from(DbContext.entities.values()),
     invalidWhereValuesBehavior: {
       undefined: 'ignore',
     },
@@ -69,11 +72,10 @@ DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 
 ## Adding new entities
 
-1. Create the entity in `src/domain/entities/`.
-2. Include it in the `entities` array of `dataSourceFactory`.
-3. Generate and apply the migration.
+1. Create the entity in `src/domain/entities/` with `@Entity` from `@/core/database/entity`.
+2. Generate and apply the migration.
 
-`migration-datasource.ts` discovers entities automatically via glob — no need to register them manually there.
+The `@Entity` decorator registers the class in `DbContext.entities`, used by `dataSourceFactory` at runtime. `migration-datasource.ts` discovers entities automatically via glob — no manual registration is needed in either place.
 
 ## InfraModule
 

--- a/libs/doc/markdown/en/infra/migrations.md
+++ b/libs/doc/markdown/en/infra/migrations.md
@@ -76,15 +76,14 @@ export default new DataSource({
 });
 ```
 
-Entities are discovered by **glob** — just create the file in `src/domain/entities/`. The runtime `dataSourceFactory`, however, lists entities explicitly in the `entities` array.
+Entities are discovered by **glob** — just create the file in `src/domain/entities/` with the core `@Entity` decorator. The runtime `dataSourceFactory` reads entities registered automatically in `DbContext.entities`.
 
 ## Recommended workflow
 
-1. Change or create entities in `src/domain/entities/`.
-2. Register new entities in `dataSourceFactory` (runtime).
-3. Run `bun run migration:generate`.
-4. Review the generated file in `src/infra/database/migrations/`.
-5. Apply with `bun run migration:run`.
+1. Change or create entities in `src/domain/entities/` with `@Entity` from `@/core/database/entity`.
+2. Run `bun run migration:generate`.
+3. Review the generated file in `src/infra/database/migrations/`.
+4. Apply with `bun run migration:run`.
 
 ## Existing migrations in the template
 

--- a/libs/doc/markdown/pt/core/bases-reutilizaveis.md
+++ b/libs/doc/markdown/pt/core/bases-reutilizaveis.md
@@ -126,6 +126,18 @@ export class RepositoryBase<T extends ObjectLiteral> {
 }
 ```
 
+## Entity
+
+Marque entidades de domínio com `@Entity` de `@/core/database/entity`. O decorador aplica o `@Entity` do TypeORM e registra a classe em `DbContext.entities`:
+
+```typescript
+// src/core/database/entity.ts
+import { Entity } from '@/core/database/entity';
+
+@Entity('person')
+export class Person extends EntityBase<Person> {}
+```
+
 ## EntityBase
 
 Entidades de domínio estendem `EntityBase`, que por sua vez estende `ObjectClass`:

--- a/libs/doc/markdown/pt/domain/entidades.md
+++ b/libs/doc/markdown/pt/domain/entidades.md
@@ -4,18 +4,48 @@ slug: entidades
 category: domain
 docKey: domain/entidades
 order: 1
-description: Modelagem de entidades TypeORM com EntityBase e decorador AutoMap.
+description: Modelagem de entidades com Entity do core, EntityBase e decorador AutoMap.
 ---
 
 # Entidades
 
-Entidades representam o modelo de domínio persistido no banco. Elas ficam em `src/domain/entities` e usam decoradores TypeORM combinados com `@AutoMap()` para o sistema de mapeamento.
+Entidades representam o modelo de domínio persistido no banco. Elas ficam em `src/domain/entities`, usam o decorador `@Entity` do core (que encapsula o TypeORM) e combinam os demais decoradores TypeORM com `@AutoMap()` para o sistema de mapeamento.
+
+## Decorador @Entity
+
+Use `@Entity` de `@/core/database/entity` — **não** importe `Entity` de `typeorm`. Por baixo dos panos, o decorador aplica o `@Entity` do TypeORM e registra a classe em `DbContext.entities` para o `dataSourceFactory` montar o array automaticamente:
+
+```typescript
+// src/core/database/entity.ts
+import { Entity as TypeOrmEntity } from 'typeorm';
+import { DbContext } from './db-context';
+
+export function Entity(tableName: string) {
+  return function (target: Function) {
+    TypeOrmEntity(tableName)(target);
+    DbContext.entities.add(target);
+  };
+}
+```
+
+Os decoradores de coluna e relacionamento (`Column`, `OneToMany`, `ManyToOne`, etc.) continuam importados de `typeorm`.
 
 ## Entidade principal
 
 A entidade `Person` demonstra relacionamentos `OneToOne` e `OneToMany` com cascade:
 
 ```typescript
+import { EntityBase } from '@/core/base/entity.base';
+import { Entity } from '@/core/database/entity';
+import { AutoMap } from '@/core/tools/mapping';
+import {
+  Column,
+  JoinColumn,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
 @Entity('person')
 export class Person extends EntityBase<Person> {
   @PrimaryGeneratedColumn()
@@ -95,18 +125,23 @@ Isso permite ao `AutoMapper` resolver o tipo de destino ao mapear cada item da c
 
 ## Registro no DataSource
 
-Todas as entidades devem ser listadas no factory do DataSource:
+O `dataSourceFactory` lê as entidades registradas automaticamente pelo decorador `@Entity`:
 
 ```typescript
+import { DbContext } from '@/core/database/db-context';
+
 const dataSource = new DataSource({
   type: 'postgres',
   url: env.get('DATABASE_URL'),
-  entities: [Person, PersonAddress, PersonContact],
+  schema: env.get('DATABASE_SCHEMA'),
+  entities: Array.from(DbContext.entities.values()),
   invalidWhereValuesBehavior: {
     undefined: 'ignore',
   },
 });
 ```
+
+Ao decorar uma nova entidade com `@Entity`, ela já entra no DataSource em runtime — não é necessário alterar o `dataSourceFactory` manualmente.
 
 A opção `invalidWhereValuesBehavior.undefined: 'ignore'` evita que filtros opcionais (`undefined`) gerem cláusulas inválidas no TypeORM.
 
@@ -139,4 +174,4 @@ findMany(query: PersonQueryDto): Promise<ListResponse<Person>> {
 - Mantenha entidades livres de lógica HTTP (sem `@ApiProperty`).
 - Use `cascade` e `onDelete` conforme a regra de negócio do agregado.
 - Coleções persistidas são **estado completo** no `save` — substitua a lista no update; itens ausentes viram órfãos com `orphanedRowAction: 'delete'`.
-- Registre novas entidades no `dataSourceFactory` e gere migrations após alterações.
+- Use `@Entity` de `@/core/database/entity` e gere migrations após alterações de schema.

--- a/libs/doc/markdown/pt/guias/fluxo-crud-person.md
+++ b/libs/doc/markdown/pt/guias/fluxo-crud-person.md
@@ -47,9 +47,20 @@ src/
 
 ## 1. Modelar entidades
 
-Defina entidades com TypeORM e `@AutoMap()`:
+Defina entidades com `@Entity` do core e `@AutoMap()`:
 
 ```typescript
+import { EntityBase } from '@/core/base/entity.base';
+import { Entity } from '@/core/database/entity';
+import { AutoMap } from '@/core/tools/mapping';
+import {
+  Column,
+  JoinColumn,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
 @Entity('person')
 export class Person extends EntityBase<Person> {
   @PrimaryGeneratedColumn()
@@ -198,14 +209,9 @@ export class PersonModule {}
 
 Importe `PersonModule` no `AppModule`.
 
-## 8. Registrar entidades e gerar migration
+## 8. Gerar migration
 
-Adicione as entidades no `dataSourceFactory` (runtime) e gere a migration:
-
-```typescript
-// src/infra/database/data-source-factory.ts
-entities: [Person, PersonAddress, PersonContact],
-```
+Com as entidades decoradas com `@Entity` do core, o `dataSourceFactory` já as inclui via `DbContext`. Gere e aplique a migration:
 
 ```bash
 bun run migration:generate
@@ -213,7 +219,7 @@ bun run migration:run
 bun run start:dev
 ```
 
-O gerador de migrations (`migration-datasource.ts`) descobre entidades em `src/domain/entities/` por glob — o registro explícito no `dataSourceFactory` é obrigatório para o servidor em runtime.
+O gerador de migrations (`migration-datasource.ts`) descobre entidades em `src/domain/entities/` por glob.
 
 Acesse `http://localhost:3000/doc` para testar os endpoints interativamente.
 
@@ -270,7 +276,7 @@ Ao criar um recurso semelhante ao Person, percorra as etapas deste guia nesta or
 
 1. **Domain** — entidades, contrato `I<Recurso>Repository` e DTOs de consulta (se houver listagem)
 2. **Application** — handlers, requests, responses, validators e `<Recurso>Mapper.createMap()` no `MappingProvider`
-3. **Infra** — repositório concreto, provider no `RepositoryModule` e entidades no `dataSourceFactory`
+3. **Infra** — repositório concreto e provider no `RepositoryModule`
 4. **Host** — `router.config.ts`, controllers, `<Recurso>Module` e import no `AppModule`
 5. **Migrations** — `migration:generate`, revisão do arquivo gerado e `migration:run`
 

--- a/libs/doc/markdown/pt/infra/banco-de-dados.md
+++ b/libs/doc/markdown/pt/infra/banco-de-dados.md
@@ -31,13 +31,16 @@ export class DatabaseModule {}
 ## Factory do DataSource
 
 ```typescript
+import { DbContext } from '@/core/database/db-context';
+
 export const DATA_SOURCE_PROVIDER_TOKEN = 'DATA_SOURCE';
 
 export async function dataSourceFactory(env: EnvService) {
   const dataSource = new DataSource({
     type: 'postgres',
     url: env.get('DATABASE_URL'),
-    entities: [Person, PersonAddress, PersonContact],
+    schema: env.get('DATABASE_SCHEMA'),
+    entities: Array.from(DbContext.entities.values()),
     invalidWhereValuesBehavior: {
       undefined: 'ignore',
     },
@@ -69,11 +72,10 @@ DATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest
 
 ## Adicionar novas entidades
 
-1. Crie a entidade em `src/domain/entities/`.
-2. Inclua-a no array `entities` do `dataSourceFactory`.
-3. Gere e aplique a migration.
+1. Crie a entidade em `src/domain/entities/` com `@Entity` de `@/core/database/entity`.
+2. Gere e aplique a migration.
 
-O `migration-datasource.ts` descobre entidades automaticamente via glob — não é necessário registrá-las manualmente lá.
+O decorador `@Entity` registra a classe em `DbContext.entities`, usado pelo `dataSourceFactory` em runtime. O `migration-datasource.ts` descobre entidades automaticamente via glob — não é necessário registrá-las manualmente em nenhum dos dois.
 
 ## InfraModule
 

--- a/libs/doc/markdown/pt/infra/migrations.md
+++ b/libs/doc/markdown/pt/infra/migrations.md
@@ -76,15 +76,14 @@ export default new DataSource({
 });
 ```
 
-Entidades são descobertas por **glob** — basta criar o arquivo em `src/domain/entities/`. O `dataSourceFactory` de runtime, porém, lista entidades explicitamente no array `entities`.
+Entidades são descobertas por **glob** — basta criar o arquivo em `src/domain/entities/` com `@Entity` do core. O `dataSourceFactory` de runtime lê as entidades registradas automaticamente em `DbContext.entities`.
 
 ## Fluxo recomendado
 
-1. Altere ou crie entidades em `src/domain/entities/`.
-2. Registre novas entidades no `dataSourceFactory` (runtime).
-3. Execute `bun run migration:generate`.
-4. Revise o arquivo gerado em `src/infra/database/migrations/`.
-5. Aplique com `bun run migration:run`.
+1. Altere ou crie entidades em `src/domain/entities/` com `@Entity` de `@/core/database/entity`.
+2. Execute `bun run migration:generate`.
+3. Revise o arquivo gerado em `src/infra/database/migrations/`.
+4. Aplique com `bun run migration:run`.
 
 ## Migrations existentes no template
 

--- a/libs/doc/site/public/llm-en.txt
+++ b/libs/doc/site/public/llm-en.txt
@@ -26,7 +26,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Domain
 
-- [Entities](markdown/en/domain/entities.md): TypeORM entity modeling with EntityBase and the AutoMap decorator.
+- [Entities](markdown/en/domain/entities.md): Entity modeling with core Entity decorator, EntityBase, and AutoMap.
 - [Repository contracts](markdown/en/domain/repository-contracts.md): Abstract repository classes and query DTOs in the domain.
 
 ## Application

--- a/libs/doc/site/public/llm.txt
+++ b/libs/doc/site/public/llm.txt
@@ -26,7 +26,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Domain
 
-- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades TypeORM com EntityBase e decorador AutoMap.
+- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades com Entity do core, EntityBase e decorador AutoMap.
 - [Contratos de repositório](markdown/pt/domain/contratos-repositorio.md): Classes abstratas de repositório e DTOs de consulta no domínio.
 
 ## Application

--- a/libs/doc/site/public/llms-en.txt
+++ b/libs/doc/site/public/llms-en.txt
@@ -26,7 +26,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Domain
 
-- [Entities](markdown/en/domain/entities.md): TypeORM entity modeling with EntityBase and the AutoMap decorator.
+- [Entities](markdown/en/domain/entities.md): Entity modeling with core Entity decorator, EntityBase, and AutoMap.
 - [Repository contracts](markdown/en/domain/repository-contracts.md): Abstract repository classes and query DTOs in the domain.
 
 ## Application

--- a/libs/doc/site/public/llms.txt
+++ b/libs/doc/site/public/llms.txt
@@ -26,7 +26,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Domain
 
-- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades TypeORM com EntityBase e decorador AutoMap.
+- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades com Entity do core, EntityBase e decorador AutoMap.
 - [Contratos de repositório](markdown/pt/domain/contratos-repositorio.md): Classes abstratas de repositório e DTOs de consulta no domínio.
 
 ## Application

--- a/libs/doc/txt/llm-en.txt
+++ b/libs/doc/txt/llm-en.txt
@@ -26,7 +26,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Domain
 
-- [Entities](markdown/en/domain/entities.md): TypeORM entity modeling with EntityBase and the AutoMap decorator.
+- [Entities](markdown/en/domain/entities.md): Entity modeling with core Entity decorator, EntityBase, and AutoMap.
 - [Repository contracts](markdown/en/domain/repository-contracts.md): Abstract repository classes and query DTOs in the domain.
 
 ## Application

--- a/libs/doc/txt/llm.txt
+++ b/libs/doc/txt/llm.txt
@@ -26,7 +26,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Domain
 
-- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades TypeORM com EntityBase e decorador AutoMap.
+- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades com Entity do core, EntityBase e decorador AutoMap.
 - [Contratos de repositório](markdown/pt/domain/contratos-repositorio.md): Classes abstratas de repositório e DTOs de consulta no domínio.
 
 ## Application

--- a/libs/doc/txt/llms-en.txt
+++ b/libs/doc/txt/llms-en.txt
@@ -26,7 +26,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 
 ## Domain
 
-- [Entities](markdown/en/domain/entities.md): TypeORM entity modeling with EntityBase and the AutoMap decorator.
+- [Entities](markdown/en/domain/entities.md): Entity modeling with core Entity decorator, EntityBase, and AutoMap.
 - [Repository contracts](markdown/en/domain/repository-contracts.md): Abstract repository classes and query DTOs in the domain.
 
 ## Application

--- a/libs/doc/txt/llms.txt
+++ b/libs/doc/txt/llms.txt
@@ -26,7 +26,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 
 ## Domain
 
-- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades TypeORM com EntityBase e decorador AutoMap.
+- [Entidades](markdown/pt/domain/entidades.md): Modelagem de entidades com Entity do core, EntityBase e decorador AutoMap.
 - [Contratos de repositório](markdown/pt/domain/contratos-repositorio.md): Classes abstratas de repositório e DTOs de consulta no domínio.
 
 ## Application


### PR DESCRIPTION
- Introduced the core `@Entity` decorator for domain entities, clarifying its usage and registration in `DbContext.entities`.
- Updated descriptions and examples across multiple documentation files to reflect the new entity modeling approach.
- Removed the need for manual entity registration in `dataSourceFactory`, streamlining the migration process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or schema impact.
> 
> **Overview**
> Updates **English and Portuguese** docs (and mirrored **LLM index** files) to describe domain entities via the core **`@Entity`** decorator from `@/core/database/entity` instead of importing TypeORM’s `Entity` directly.
> 
> **New guidance:** the decorator wraps TypeORM and registers each class in **`DbContext.entities`**, so runtime **`dataSourceFactory`** uses `Array.from(DbContext.entities.values())` (with **`DATABASE_SCHEMA`**) and **manual entity lists are removed** from guides for database setup, migrations, and the Person CRUD flow.
> 
> Adds an **Entity** section under reusable bases, expands the entities page with decorator implementation and import examples, and refreshes best-practice bullets to “use core `@Entity` + run migrations” rather than “register in `dataSourceFactory`.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624c304948092c7d746ec0e726a25d54e0f0c356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->