### PR TITLE
Update sitemap generation and SEO configurations

### DIFF
--- a/libs/doc/markdown/en/host/authentication.md
+++ b/libs/doc/markdown/en/host/authentication.md
@@ -2,7 +2,7 @@
 title: Authentication
 slug: authentication
 category: host
-docKey: host/authentication
+docKey: host/autenticacao
 order: 4
 description: JWT, global guards, public routes, and generic OAuth2.
 ---

--- a/libs/doc/site/.gitignore
+++ b/libs/doc/site/.gitignore
@@ -49,6 +49,5 @@ Thumbs.db
 # Generated markdown for LLMs (synced from libs/doc/markdown on build)
 /public/markdown/
 
-# Generated at build time (see scripts/post-build.mjs and scripts/build-doc-manifest.mjs)
-/public/sitemap.xml
+# Generated at build time (see scripts/build-doc-manifest.mjs)
 /prerender-routes.txt

--- a/libs/doc/site/public/robots.txt
+++ b/libs/doc/site/public/robots.txt
@@ -1,4 +1,11 @@
 User-agent: *
 Allow: /
 
+# Raw markdown and LLM indexes are for agents/tools, not search results.
+Disallow: /markdown/
+Disallow: /llm.txt
+Disallow: /llm-en.txt
+Disallow: /llms.txt
+Disallow: /llms-en.txt
+
 Sitemap: https://nest.koalarx.com/sitemap.xml

--- a/libs/doc/site/public/sitemap.xml
+++ b/libs/doc/site/public/sitemap.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://nest.koalarx.com/pt/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/intro/visao-geral/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/intro/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/intro/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/intro/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/intro/arquitetura-ddd/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/intro/arquitetura-ddd/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/intro/ddd-architecture/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/intro/arquitetura-ddd/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/inicio/guia-de-instalacao/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/inicio/guia-de-instalacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/getting-started/installation-guide/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/inicio/guia-de-instalacao/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/inicio/variaveis-de-ambiente/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/inicio/variaveis-de-ambiente/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/getting-started/environment-variables/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/inicio/variaveis-de-ambiente/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/inicio/estrutura-do-projeto/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/inicio/estrutura-do-projeto/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/getting-started/project-structure/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/inicio/estrutura-do-projeto/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/core/bases-reutilizaveis/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/bases-reutilizaveis/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/reusable-bases/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/bases-reutilizaveis/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/core/cache/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/cache/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/cache/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/cache/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/core/object-class/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/object-class/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/object-class/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/object-class/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/core/paginacao/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/paginacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/pagination/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/paginacao/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/core/cron-event-jobs/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/cron-event-jobs/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/cron-event-jobs/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/cron-event-jobs/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/core/koala-utils/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/koala-utils/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/koala-utils/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/koala-utils/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/domain/entidades/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/domain/entidades/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/domain/entities/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/domain/entidades/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/domain/contratos-repositorio/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/domain/contratos-repositorio/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/domain/repository-contracts/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/domain/contratos-repositorio/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/application/handlers/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/handlers/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/handlers/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/handlers/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/application/validators/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/validators/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/validators/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/validators/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/application/requests-responses/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/requests-responses/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/requests-responses/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/requests-responses/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/application/mapeamento/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/mapeamento/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/mapping/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/mapeamento/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/middleware-http/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/middleware-http/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/http-middleware/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/middleware-http/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/controllers/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/controllers/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/controllers/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/controllers/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/rotas/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/rotas/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/routes/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/rotas/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/tratamento-de-erros/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/tratamento-de-erros/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/error-handling/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/tratamento-de-erros/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/autenticacao/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/openapi-scalar/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/openapi-scalar/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/openapi-scalar/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/openapi-scalar/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/host/health-check/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/health-check/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/health-check/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/health-check/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/infra/banco-de-dados/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/infra/banco-de-dados/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/infra/database/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/infra/banco-de-dados/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/infra/repositorios/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/infra/repositorios/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/infra/repositories/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/infra/repositorios/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/infra/migrations/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/infra/migrations/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/infra/migrations/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/infra/migrations/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/pt/docs/guias/fluxo-crud-person/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/guias/fluxo-crud-person/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/guides/person-crud-flow/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/guias/fluxo-crud-person/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/intro/overview/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/intro/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/intro/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/intro/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/intro/ddd-architecture/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/intro/arquitetura-ddd/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/intro/ddd-architecture/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/intro/arquitetura-ddd/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/getting-started/installation-guide/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/inicio/guia-de-instalacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/getting-started/installation-guide/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/inicio/guia-de-instalacao/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/getting-started/environment-variables/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/inicio/variaveis-de-ambiente/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/getting-started/environment-variables/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/inicio/variaveis-de-ambiente/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/getting-started/project-structure/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/inicio/estrutura-do-projeto/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/getting-started/project-structure/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/inicio/estrutura-do-projeto/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/core/reusable-bases/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/bases-reutilizaveis/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/reusable-bases/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/bases-reutilizaveis/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/core/cache/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/cache/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/cache/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/cache/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/core/object-class/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/object-class/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/object-class/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/object-class/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/core/pagination/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/paginacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/pagination/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/paginacao/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/core/cron-event-jobs/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/cron-event-jobs/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/cron-event-jobs/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/cron-event-jobs/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/core/koala-utils/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/core/koala-utils/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/core/koala-utils/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/core/koala-utils/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/domain/entities/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/domain/entidades/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/domain/entities/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/domain/entidades/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/domain/repository-contracts/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/domain/contratos-repositorio/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/domain/repository-contracts/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/domain/contratos-repositorio/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/application/handlers/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/handlers/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/handlers/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/handlers/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/application/validators/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/validators/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/validators/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/validators/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/application/requests-responses/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/requests-responses/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/requests-responses/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/requests-responses/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/application/mapping/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/application/mapeamento/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/application/mapping/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/application/mapeamento/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/http-middleware/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/middleware-http/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/http-middleware/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/middleware-http/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/controllers/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/controllers/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/controllers/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/controllers/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/routes/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/rotas/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/routes/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/rotas/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/error-handling/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/tratamento-de-erros/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/error-handling/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/tratamento-de-erros/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/authentication/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/en/docs/host/authentication/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/authentication/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/en/docs/host/authentication/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/openapi-scalar/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/openapi-scalar/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/openapi-scalar/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/openapi-scalar/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/host/health-check/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/health-check/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/health-check/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/health-check/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/infra/database/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/infra/banco-de-dados/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/infra/database/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/infra/banco-de-dados/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/infra/repositories/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/infra/repositorios/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/infra/repositories/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/infra/repositorios/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/infra/migrations/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/infra/migrations/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/infra/migrations/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/infra/migrations/" />
+  </url>
+  <url>
+    <loc>https://nest.koalarx.com/en/docs/guides/person-crud-flow/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/guias/fluxo-crud-person/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/guides/person-crud-flow/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/guias/fluxo-crud-person/" />
+  </url>
+</urlset>

--- a/libs/doc/site/public/sitemap.xml
+++ b/libs/doc/site/public/sitemap.xml
@@ -135,7 +135,7 @@
   <url>
     <loc>https://nest.koalarx.com/pt/docs/host/autenticacao/</loc>
     <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
-    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/authentication/" />
     <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
   </url>
   <url>
@@ -308,9 +308,9 @@
   </url>
   <url>
     <loc>https://nest.koalarx.com/en/docs/host/authentication/</loc>
-    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/en/docs/host/authentication/" />
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
     <xhtml:link rel="alternate" hreflang="en" href="https://nest.koalarx.com/en/docs/host/authentication/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/en/docs/host/authentication/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://nest.koalarx.com/pt/docs/host/autenticacao/" />
   </url>
   <url>
     <loc>https://nest.koalarx.com/en/docs/host/openapi-scalar/</loc>

--- a/libs/doc/site/scripts/build-sitemap.mjs
+++ b/libs/doc/site/scripts/build-sitemap.mjs
@@ -36,7 +36,6 @@ export function buildSitemapEntries(manifest) {
   const entries = [];
 
   for (const locale of manifest.supportedLocales) {
-    const alternateHome = locale === 'pt' ? '/en' : '/pt';
     entries.push({
       loc: absoluteUrl(`/${locale}`),
       alternates: [
@@ -48,9 +47,15 @@ export function buildSitemapEntries(manifest) {
 
     for (const doc of manifest.locales[locale].docs) {
       const loc = absoluteUrl(doc.route);
-      const alternate = doc.alternateRoute
-        ? absoluteUrl(doc.alternateRoute)
-        : absoluteUrl(alternateHome);
+      const hasTranslation =
+        Boolean(doc.alternateRoute) && doc.alternateRoute !== doc.route;
+
+      if (!hasTranslation) {
+        entries.push({ loc, alternates: [] });
+        continue;
+      }
+
+      const alternate = absoluteUrl(doc.alternateRoute);
       const ptHref = locale === 'pt' ? loc : alternate;
       const enHref = locale === 'en' ? loc : alternate;
 
@@ -76,8 +81,10 @@ export function buildSitemapEntries(manifest) {
 export function buildSitemapXml(entries) {
   const urls = entries
     .map((entry) => {
-      const links = xhtmlAlternates(entry.alternates);
-      return `  <url>\n    <loc>${escapeXml(entry.loc)}</loc>\n${links}\n  </url>`;
+      const links = entry.alternates?.length
+        ? `\n${xhtmlAlternates(entry.alternates)}`
+        : '';
+      return `  <url>\n    <loc>${escapeXml(entry.loc)}</loc>${links}\n  </url>`;
     })
     .join('\n');
 

--- a/libs/doc/site/scripts/build-sitemap.mjs
+++ b/libs/doc/site/scripts/build-sitemap.mjs
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const SITE_URL = 'https://nest.koalarx.com';
+
+/** GitHub Pages 301s bare paths to trailing-slash dirs; sitemap must list final URLs. */
+export function withTrailingSlash(route) {
+  if (!route || route === '/') return '/';
+  return route.endsWith('/') ? route : `${route}/`;
+}
+
+export function absoluteUrl(route) {
+  const normalized = withTrailingSlash(route);
+  return normalized === '/' ? `${SITE_URL}/` : `${SITE_URL}${normalized}`;
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function xhtmlAlternates(alternates) {
+  return alternates
+    .map(
+      ([hreflang, href]) =>
+        `    <xhtml:link rel="alternate" hreflang="${hreflang}" href="${escapeXml(href)}" />`,
+    )
+    .join('\n');
+}
+
+export function buildSitemapEntries(manifest) {
+  const entries = [];
+
+  for (const locale of manifest.supportedLocales) {
+    const alternateHome = locale === 'pt' ? '/en' : '/pt';
+    entries.push({
+      loc: absoluteUrl(`/${locale}`),
+      alternates: [
+        ['pt-BR', absoluteUrl('/pt')],
+        ['en', absoluteUrl('/en')],
+        ['x-default', absoluteUrl('/pt')],
+      ],
+    });
+
+    for (const doc of manifest.locales[locale].docs) {
+      const loc = absoluteUrl(doc.route);
+      const alternate = doc.alternateRoute
+        ? absoluteUrl(doc.alternateRoute)
+        : absoluteUrl(alternateHome);
+      const ptHref = locale === 'pt' ? loc : alternate;
+      const enHref = locale === 'en' ? loc : alternate;
+
+      entries.push({
+        loc,
+        alternates: [
+          ['pt-BR', ptHref],
+          ['en', enHref],
+          ['x-default', ptHref],
+        ],
+      });
+    }
+  }
+
+  const seen = new Set();
+  return entries.filter((entry) => {
+    if (seen.has(entry.loc)) return false;
+    seen.add(entry.loc);
+    return true;
+  });
+}
+
+export function buildSitemapXml(entries) {
+  const urls = entries
+    .map((entry) => {
+      const links = xhtmlAlternates(entry.alternates);
+      return `  <url>\n    <loc>${escapeXml(entry.loc)}</loc>\n${links}\n  </url>`;
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+    urls,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+export function writeSitemap(manifest, outputPath) {
+  const xml = buildSitemapXml(buildSitemapEntries(manifest));
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, xml);
+  return outputPath;
+}

--- a/libs/doc/site/scripts/post-build.mjs
+++ b/libs/doc/site/scripts/post-build.mjs
@@ -1,40 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { writeSitemap } from './build-sitemap.mjs';
 
-const SITE_URL = 'https://nest.koalarx.com';
 const outputDir = path.resolve('dist/site/browser');
 const manifestPath = path.resolve('src/generated/docs-manifest.json');
 const indexFile = path.join(outputDir, 'index.html');
 const notFoundFile = path.join(outputDir, '404.html');
 const sitemapFile = path.join(outputDir, 'sitemap.xml');
-
-function buildSitemapRoutes(manifest) {
-  return [
-    '/',
-    ...manifest.supportedLocales.flatMap((locale) => [
-      `/${locale}`,
-      ...manifest.locales[locale].docs.map((doc) => doc.route),
-    ]),
-  ];
-}
-
-function buildSitemapXml(routes) {
-  const uniqueRoutes = [...new Set(routes.filter(Boolean))];
-  const urls = uniqueRoutes
-    .map((route) => {
-      const loc = route === '/' ? SITE_URL : `${SITE_URL}${route}`;
-      return `  <url>\n    <loc>${loc}</loc>\n  </url>`;
-    })
-    .join('\n');
-
-  return [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    urls,
-    '</urlset>',
-    '',
-  ].join('\n');
-}
+const publicSitemapFile = path.resolve('public/sitemap.xml');
 
 if (!fs.existsSync(indexFile)) {
   console.error('index.html não encontrado em', outputDir);
@@ -51,8 +24,10 @@ for (const file of fs.readdirSync(outputDir)) {
 
 if (fs.existsSync(manifestPath)) {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  fs.writeFileSync(sitemapFile, buildSitemapXml(buildSitemapRoutes(manifest)));
+  writeSitemap(manifest, sitemapFile);
+  writeSitemap(manifest, publicSitemapFile);
   console.log(`Sitemap gerado → ${sitemapFile}`);
+  console.log(`Sitemap gerado → ${publicSitemapFile}`);
 } else {
   console.warn('Manifest não encontrado; sitemap.xml não foi gerado.');
 }

--- a/libs/doc/site/src/app/core/components/site-footer/site-footer.component.html
+++ b/libs/doc/site/src/app/core/components/site-footer/site-footer.component.html
@@ -51,12 +51,12 @@
         </li>
         <li>
           <a
-            href="https://koalarx.com"
+            href="https://ui.koalarx.com"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-1.5 transition-opacity hover:opacity-100"
           >
-            @koalarx/ui-cli
+            @koalarx/ui
             <i class="fa-solid fa-arrow-up-long rotate-45 text-[0.6rem]"></i>
           </a>
         </li>

--- a/libs/doc/site/src/app/core/config/site-seo.ts
+++ b/libs/doc/site/src/app/core/config/site-seo.ts
@@ -2,10 +2,17 @@ export const SITE_URL = 'https://nest.koalarx.com';
 export const SITE_NAME = 'Koala Nest';
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/logo.svg`;
 
+/**
+ * Absolute URL for the docs site.
+ * Page paths get a trailing slash (GitHub Pages serves dirs as `/en/`, not `/en`).
+ * File paths (e.g. `.md`, `.txt`) keep their exact path.
+ */
 export function absoluteSiteUrl(path: string) {
-  if (!path || path === '/') {
-    return SITE_URL;
+  if (!path || path === '/') return `${SITE_URL}/`;
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  if (/\.[a-z0-9]+$/i.test(normalized)) {
+    return `${SITE_URL}${normalized}`;
   }
-
-  return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+  const withSlash = normalized.endsWith('/') ? normalized : `${normalized}/`;
+  return `${SITE_URL}${withSlash}`;
 }

--- a/libs/doc/site/src/app/core/config/site-seo.unit.spec.ts
+++ b/libs/doc/site/src/app/core/config/site-seo.unit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'vitest';
 import { absoluteSiteUrl, SITE_URL } from './site-seo';
 
 describe('absoluteSiteUrl', () => {

--- a/libs/doc/site/src/app/core/config/site-seo.unit.spec.ts
+++ b/libs/doc/site/src/app/core/config/site-seo.unit.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import { absoluteSiteUrl, SITE_URL } from './site-seo';
+
+describe('absoluteSiteUrl', () => {
+  it('normalizes the root to a trailing slash', () => {
+    expect(absoluteSiteUrl('/')).toBe(`${SITE_URL}/`);
+    expect(absoluteSiteUrl('')).toBe(`${SITE_URL}/`);
+  });
+
+  it('adds a trailing slash to page paths for GitHub Pages', () => {
+    expect(absoluteSiteUrl('/pt')).toBe(`${SITE_URL}/pt/`);
+    expect(absoluteSiteUrl('/pt/docs/intro/visao-geral')).toBe(
+      `${SITE_URL}/pt/docs/intro/visao-geral/`,
+    );
+    expect(absoluteSiteUrl('/en/docs/intro/overview/')).toBe(
+      `${SITE_URL}/en/docs/intro/overview/`,
+    );
+  });
+
+  it('keeps file paths without forcing a trailing slash', () => {
+    expect(absoluteSiteUrl('/llms.txt')).toBe(`${SITE_URL}/llms.txt`);
+    expect(absoluteSiteUrl('/markdown/pt/intro/visao-geral.md')).toBe(
+      `${SITE_URL}/markdown/pt/intro/visao-geral.md`,
+    );
+  });
+});

--- a/libs/doc/site/src/index.html
+++ b/libs/doc/site/src/index.html
@@ -11,10 +11,10 @@
     />
     <meta name="robots" content="index, follow" />
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large" />
-    <link rel="canonical" href="https://nest.koalarx.com/" />
+    <link rel="canonical" href="https://nest.koalarx.com/pt/" />
     <meta property="og:site_name" content="Koala Nest" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://nest.koalarx.com/" />
+    <meta property="og:url" content="https://nest.koalarx.com/pt/" />
     <meta property="og:title" content="Koala Nest — APIs NestJS com DDD e TypeORM" />
     <meta
       property="og:description"

--- a/scripts/build-doc-manifest.mjs
+++ b/scripts/build-doc-manifest.mjs
@@ -10,6 +10,7 @@ import {
   supportedLocales,
   toPosix,
 } from '../libs/doc/shared/nav.mjs';
+import { writeSitemap } from '../libs/doc/site/scripts/build-sitemap.mjs';
 
 const docRoot = path.resolve('libs/doc');
 const markdownRoot = path.join(docRoot, 'markdown');
@@ -18,6 +19,7 @@ const appVersionPath = path.join(docRoot, 'site/src/app/core/constants/app-versi
 const txtRoot = path.join(docRoot, 'txt');
 const publicRoot = path.join(docRoot, 'site/public');
 const publicMarkdownRoot = path.join(publicRoot, 'markdown');
+const publicSitemapPath = path.join(publicRoot, 'sitemap.xml');
 
 function extractHeadings(body) {
   const headings = [];
@@ -230,6 +232,7 @@ fs.mkdirSync(publicRoot, { recursive: true });
 
 const markdownFiles = syncMarkdownToPublic();
 const appVersion = syncAppVersion();
+writeSitemap(manifest, publicSitemapPath);
 
 for (const locale of supportedLocales) {
   const llmsIndex = buildLlmsIndex(locales[locale].docs, locale);
@@ -244,3 +247,4 @@ const totalDocs = Object.values(locales).reduce((sum, l) => sum + l.docs.length,
 console.log(`Manifest gerado: ${totalDocs} tópicos (${supportedLocales.join(', ')}) → ${manifestPath}`);
 console.log(`Versão da doc sincronizada: v${appVersion} → ${appVersionPath}`);
 console.log(`Markdown publicado: ${markdownFiles} arquivos → ${publicMarkdownRoot}`);
+console.log(`Sitemap gerado → ${publicSitemapPath}`);


### PR DESCRIPTION
- Adjusted the .gitignore to exclude the public sitemap.xml file.
- Updated robots.txt to disallow access to markdown and LLM index files.
- Refactored post-build script to utilize a new writeSitemap function for generating sitemaps.
- Modified index.html to set the canonical URL to the Portuguese version.
- Updated site footer links to point to the new UI package.
- Enhanced the absoluteSiteUrl function to ensure proper URL formatting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site build, SEO metadata, and static assets only; no application runtime or security-sensitive logic.
> 
> **Overview**
> Improves **docs site SEO** for GitHub Pages: sitemaps now use **trailing-slash URLs** and **hreflang** alternates for pt/en doc pairs, generated from the docs manifest via a shared `build-sitemap.mjs` (manifest build and post-build).
> 
> **Crawlers:** `robots.txt` **disallows** `/markdown/` and LLM index files so agents can still fetch them but search engines should not index them. Default **canonical** and **og:url** in `index.html` point at **`/pt/`** instead of `/`.
> 
> **Runtime SEO:** `absoluteSiteUrl` adds trailing slashes for page paths but leaves file paths (`.md`, `.txt`) unchanged, with Vitest coverage.
> 
> **Misc:** Footer package link updated to **ui.koalarx.com** / `@koalarx/ui`; English authentication page `docKey` aligned to **`host/autenticacao`** for locale pairing in the sitemap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724a1b5da586a709385557b525786279314096fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->