### PR TITLE
4.3.0 — API Key auth e contexto AI na CLI

### DIFF
--- a/.agents/agents.md
+++ b/.agents/agents.md
@@ -20,18 +20,25 @@ Useful entry points: [bases](https://nest.koalarx.com/markdown/pt/core/bases-reu
 | Site docs / frontmatter / `llms.txt` pipeline | `.agents/documentation.md` |
 | User-facing CLI/template/API change (patch notes) | `.agents/patch-notes.md` |
 | Generated-project validation rules | `libs/cli/constants/cli-project-checklist.ts` |
+| Class member order / TypeScript style in template | `.agents/typescript-conventions.md` |
+| Consumer AI context (`kl-nest new`/`add`) | `libs/cli/assets/ai-context/` — keep in sync after template/docs/pattern changes (see below) |
 
 ## Hard constraints
 
 - Layers: `application` / `domain` / `host` / `infra` / `core` (+ `test`). Extend template bases only.
 - Prefer Bun; apps target NestJS 11, TypeORM + PostgreSQL, Zod 4.
 - `@koalarx/utils` ≥ 5: `import '@koalarx/utils/prototypes'` in `src/host/main.ts` and test setups; prefer native prototypes (`.maskCpf()`, `.orderBy()`). Keep `delay`, `randomString`, holidays as explicit imports.
+- Class members: **private → protected → public** (attrs then methods; public attrs after protected); within a group, **dependency order**. See `.agents/typescript-conventions.md`.
 - Do not invent undocumented APIs.
 
 ## Maintaining agent context
 
+Context must stay **VS Code (Copilot) + Cursor compatible**. Same files, no editor fork.
+
 - Canonical body: **`.agents/agents.md` only**. Root `AGENTS.md` and `.github/copilot-instructions.md` are symlinks — never duplicate the text.
 - Keep this file short: index + hard constraints only.
 - Put detailed procedures in `.agents/*.md` playbooks; link them from the When→Read map (repo-root paths).
-- Path-scoped: nested `AGENTS.md` and Copilot `*.instructions.md` are pointers only — no copied bodies.
+- Path-scoped: nested `AGENTS.md` and `.github/instructions/*.instructions.md` (`applyTo` frontmatter) are pointers only — no copied bodies.
+- **Never** create `.cursor/`, `.cursor/rules/`, or `*.mdc` Cursor-only rules. Cursor already reads `AGENTS.md` / Copilot instructions; path-scoped guidance goes under `.github/instructions/`.
 - Prefer adding a reference over pasting long guidance here.
+- **Consumer AI scaffolding:** `libs/cli/assets/ai-context/` is copied into projects via `kl-nest new` / `add ai-context`. After changing template layers, docs URLs, bases, auth/features, or hard constraints that agents must know, **review and update** those assets (and related CLI install/detect if needed) so generated vibecoding context stays accurate.

--- a/.agents/patch-notes.md
+++ b/.agents/patch-notes.md
@@ -6,6 +6,7 @@ Ao introduzir mudanças **visíveis** na CLI, nos templates (`libs/koala-nest`),
 2. Atualize **`CHANGELOG.md`** na raiz na seção da versão que está subindo (sem seção `[Unreleased]` — só o que já foi ou será publicado).
 3. Se a mudança afetar onboarding ou scripts destacados, ajuste o **`README.md`** (links ou bullets em “Novidades” / scripts).
 4. Não mantenha camadas legadas “só por compatibilidade” na CLI — documente o upgrade nos patch notes.
+5. Se a mudança alterar padrões que agentes devem seguir no projeto gerado (camadas, bases, auth, docs URLs, utils), revise **`libs/cli/assets/ai-context/`** (`AGENTS.md`, `.cursor/rules`, Copilot instructions) para o vibecoding dos consumidores não ficar desatualizado.
 
 ## O que registrar
 

--- a/.agents/typescript-conventions.md
+++ b/.agents/typescript-conventions.md
@@ -1,0 +1,66 @@
+# Convenções TypeScript (template / CLI)
+
+Regras de estilo para código gerado e mantido neste monorepo (`libs/koala-nest`, patches da CLI).
+
+## Ordem de membros em classes
+
+### Visibilidade
+
+`private` → `protected` → `public` (vale para **atributos** e **métodos**).
+
+### Ordem estrutural
+
+1. Atributos privados
+2. Atributos protected
+3. Atributos públicos
+4. Construtor
+5. Métodos privados
+6. Métodos protected
+7. Métodos públicos
+
+### Ordem por dependência
+
+Dentro do mesmo grupo de visibilidade, ordene por **dependência**: o membro **usado** vem **antes** de quem o usa.
+
+- Helper privado que outro método privado chama → helper primeiro
+- Método que `handle()` / `validate()` chamam → antes do caller público/protegido
+- Evite referências “para cima” na lista de métodos da classe
+
+```typescript
+@Injectable()
+export class ExampleService {
+  private readonly dependency: Dependency;
+
+  protected readonly option: string;
+
+  public readonly label: string;
+
+  constructor(dependency: Dependency) {
+    this.dependency = dependency;
+    this.option = 'default';
+    this.label = 'example';
+  }
+
+  private normalize(value: string): string {
+    return value.trim();
+  }
+
+  private buildPayload(value: string): object {
+    return { value: this.normalize(value) };
+  }
+
+  protected canRun(): boolean {
+    return true;
+  }
+
+  async handle(raw: string): Promise<object> {
+    if (!this.canRun()) {
+      return {};
+    }
+
+    return this.buildPayload(raw);
+  }
+}
+```
+
+Não misture visibilidades fora dessa ordem (ex.: atributo/método público no meio de private/protected).

--- a/.github/instructions/typescript-conventions.instructions.md
+++ b/.github/instructions/typescript-conventions.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "libs/koala-nest/**/*.ts,libs/cli/**/*.ts,.agents/typescript-conventions.md"
+---
+
+Follow the TypeScript conventions playbook in `.agents/typescript-conventions.md` (path-scoped pointer only — read that file; do not invent a parallel copy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ O conteúdo principal vive em `libs/doc/markdown/{pt,en}/intro/patch-notes.md` (
 
 Formato inspirado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/).
 
+## [4.3.0] — API Key (autenticação M2M)
+
+### Added
+
+- Estratégia aditiva `api-key` na CLI (`jwt,api-key` / `oauth2,api-key` / `jwt,oauth2,api-key`).
+- CRUD `/api-key`, Passport strategy, validação de origem (`domain`/`host`/`uri`) e opção `--api-key-internal-subnet`.
+- Esquema Scalar `ApiKey` (header).
+- Documentação de autenticação e patch notes para API Key.
+- Contexto AI no `new` (prompt) e `add ai-context cursor|github`: `AGENTS.md`, `.cursor/rules` e/ou `.github/copilot-instructions.md` para vibecoding.
+- Geração automática de `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` (RS256 em base64) no `.env` ao instalar JWT, OAuth2 e/ou API Key (`new` / `add auth`).
+
+### Changed
+
+- `AuthGuard` aceita JWT Bearer e/ou header `ApiKey` quando a estratégia está instalada.
+
+Detalhes: [Patch notes — 4.3.0](https://nest.koalarx.com/pt/docs/intro/patch-notes).
+
 ## [4.2.0] — Migrations e descoberta de entidades
 
 ### Added

--- a/libs/cli/assets/ai-context/.cursor/rules/koala-application.mdc
+++ b/libs/cli/assets/ai-context/.cursor/rules/koala-application.mdc
@@ -1,0 +1,12 @@
+---
+description: Application — handlers, validators e DTOs
+globs: src/application/**/*.ts
+alwaysApply: false
+---
+
+# Application
+
+- Estenda `RequestHandlerBase`, `RequestValidatorBase` e padrões de request/response do template.
+- Validação com Zod 4 nos validators; não invente pipes Nest genéricos no lugar.
+- Mappers com AutoMap quando o projeto já usa; espelhe um handler existente (ex.: Person).
+- Receita de novo recurso: fluxo Person CRUD na documentação Nest (`llms.txt`).

--- a/libs/cli/assets/ai-context/.cursor/rules/koala-class-members.mdc
+++ b/libs/cli/assets/ai-context/.cursor/rules/koala-class-members.mdc
@@ -1,0 +1,11 @@
+---
+description: Ordem de membros em classes — private, protected, public e dependência
+globs: src/**/*.ts
+alwaysApply: false
+---
+
+# Ordem de membros em classes
+
+1. **Visibilidade (atributos e métodos):** `private` → `protected` → `public`
+2. **Estrutura:** atributos (private → protected → public) → construtor → métodos (private → protected → public)
+3. **Dependência:** no mesmo grupo, o membro usado vem antes de quem o usa

--- a/libs/cli/assets/ai-context/.cursor/rules/koala-domain.mdc
+++ b/libs/cli/assets/ai-context/.cursor/rules/koala-domain.mdc
@@ -1,0 +1,11 @@
+---
+description: Domain — entidades e contratos
+globs: src/domain/**/*.ts
+alwaysApply: false
+---
+
+# Domain
+
+- Entidades com `@Entity` de `@/core/database/entity` (registra no `DbContext`).
+- Contratos de repositório em `domain/repositories`; implementação em `infra`.
+- Sem detalhes de TypeORM Connection/QueryBuilder na entidade de domínio além do padrão do template.

--- a/libs/cli/assets/ai-context/.cursor/rules/koala-host.mdc
+++ b/libs/cli/assets/ai-context/.cursor/rules/koala-host.mdc
@@ -1,0 +1,12 @@
+---
+description: Host — controllers, rotas e security
+globs: src/host/**/*.ts
+alwaysApply: false
+---
+
+# Host
+
+- Controllers finos: delegam ao handler; usam `RouterConfig` / `RouterConfigBase` do template.
+- Não coloque regras de negócio no controller.
+- Auth/guards/decorators: reutilize o que já existe em `host/security` se auth estiver instalada.
+- OpenAPI via padrões do template (`define-documentation`, decorators locais).

--- a/libs/cli/assets/ai-context/.cursor/rules/koala-layers.mdc
+++ b/libs/cli/assets/ai-context/.cursor/rules/koala-layers.mdc
@@ -1,0 +1,17 @@
+---
+description: Camadas DDD do Koala Nest — dependências só para dentro
+globs: src/application/**/*.ts,src/domain/**/*.ts,src/host/**/*.ts,src/infra/**/*.ts,src/core/**/*.ts
+alwaysApply: false
+---
+
+# Camadas
+
+- `domain` — entidades e contratos de repositório; sem TypeORM/Nest nos detalhes de infra.
+- `application` — handlers, validators Zod, requests/responses, mappers.
+- `infra` — implementações (repos TypeORM, cache, auth services); liga contratos do domain.
+- `host` — controllers finos, modules, security, OpenAPI; orquestra handlers.
+- `core` — bases, env, utils compartilhados.
+
+Não invente imports de handlers/repos/controllers a partir de `@koalarx/nest` — o código já está em `src/`.
+
+Docs: https://nest.koalarx.com/llms.txt · https://nest.koalarx.com/llms-en.txt

--- a/libs/cli/assets/ai-context/.github/copilot-instructions.md
+++ b/libs/cli/assets/ai-context/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Koala Nest — agent instructions
+
+This project was scaffolded with `kl-nest` (Koala Nest). Application code lives under `src/` and was **copied** into the repo — do **not** invent runtime imports of handlers, repositories, or controllers from `@koalarx/nest`.
+
+## Docs first
+
+Before inventing APIs or patterns, read the relevant topic from the indexes:
+
+- Nest PT: https://nest.koalarx.com/llms.txt · EN: https://nest.koalarx.com/llms-en.txt
+- Utils: https://utils.koalarx.com/llms.txt
+
+Useful entry points: [reusable bases](https://nest.koalarx.com/markdown/en/core/reusable-bases.md), [Person CRUD flow](https://nest.koalarx.com/markdown/en/guides/person-crud-flow.md), [Koala Utils (Nest)](https://nest.koalarx.com/markdown/en/core/koala-utils.md).
+
+## Hard constraints
+
+- Layers: `application` / `domain` / `host` / `infra` / `core` (+ `test`). Depend inward only. Extend template bases (`RequestHandlerBase`, `RequestValidatorBase`, `RepositoryBase`, `RouterConfigBase`, core `@Entity`).
+- Prefer Bun; NestJS 11, TypeORM + PostgreSQL, Zod 4.
+- `@koalarx/utils` ≥ 5: `import '@koalarx/utils/prototypes'` in `src/host/main.ts` and test setups; prefer native prototypes (`.maskCpf()`, `.orderBy()`). Keep `delay`, `randomString`, holidays as explicit imports.
+- Class members: **private → protected → public** (attributes then methods; public attributes after protected); within a group, **dependency order**.
+- Do not invent undocumented APIs, decorators, or bases.
+
+## New resource recipe
+
+1. Follow the Person CRUD layout in docs (handler → validator/request/response → mapper → entity → repository contract → infra repo → controller + `RouterConfig`).
+2. Wire the module in `app.module` / feature module; bind the repository in `RepositoryModule`.
+3. Register entities via core `@Entity` (feeds `DbContext`); add a TypeORM migration when the schema changes.
+4. Auth/cache/health/cron/events may be present — reuse existing patterns in this repo; do not assume features that are not installed.
+
+## Optional features
+
+If `kl-nest add` installed auth, Redis cache, health, cron, or events, match the local files and modules already in the tree. Public routes use the project’s auth decorators; inject `ILoggedUserInfoService` when you need the logged user.

--- a/libs/cli/assets/ai-context/AGENTS.md
+++ b/libs/cli/assets/ai-context/AGENTS.md
@@ -1,0 +1,31 @@
+# Koala Nest — agent instructions
+
+This project was scaffolded with `kl-nest` (Koala Nest). Application code lives under `src/` and was **copied** into the repo — do **not** invent runtime imports of handlers, repositories, or controllers from `@koalarx/nest`.
+
+## Docs first
+
+Before inventing APIs or patterns, read the relevant topic from the indexes:
+
+- Nest PT: https://nest.koalarx.com/llms.txt · EN: https://nest.koalarx.com/llms-en.txt
+- Utils: https://utils.koalarx.com/llms.txt
+
+Useful entry points: [reusable bases](https://nest.koalarx.com/markdown/en/core/reusable-bases.md), [Person CRUD flow](https://nest.koalarx.com/markdown/en/guides/person-crud-flow.md), [Koala Utils (Nest)](https://nest.koalarx.com/markdown/en/core/koala-utils.md).
+
+## Hard constraints
+
+- Layers: `application` / `domain` / `host` / `infra` / `core` (+ `test`). Depend inward only. Extend template bases (`RequestHandlerBase`, `RequestValidatorBase`, `RepositoryBase`, `RouterConfigBase`, core `@Entity`).
+- Prefer Bun; NestJS 11, TypeORM + PostgreSQL, Zod 4.
+- `@koalarx/utils` ≥ 5: `import '@koalarx/utils/prototypes'` in `src/host/main.ts` and test setups; prefer native prototypes (`.maskCpf()`, `.orderBy()`). Keep `delay`, `randomString`, holidays as explicit imports.
+- Class members: **private → protected → public** (attributes then methods; public attributes after protected); within a group, **dependency order**.
+- Do not invent undocumented APIs, decorators, or bases.
+
+## New resource recipe
+
+1. Follow the Person CRUD layout in docs (handler → validator/request/response → mapper → entity → repository contract → infra repo → controller + `RouterConfig`).
+2. Wire the module in `app.module` / feature module; bind the repository in `RepositoryModule`.
+3. Register entities via core `@Entity` (feeds `DbContext`); add a TypeORM migration when the schema changes.
+4. Auth/cache/health/cron/events may be present — reuse existing patterns in this repo; do not assume features that are not installed.
+
+## Optional features
+
+If `kl-nest add` installed auth, Redis cache, health, cron, or events, match the local files and modules already in the tree. Public routes use the project’s auth decorators; inject `ILoggedUserInfoService` when you need the logged user.

--- a/libs/cli/commands/add/index.ts
+++ b/libs/cli/commands/add/index.ts
@@ -1,9 +1,14 @@
 import * as p from '@clack/prompts';
 import color from 'picocolors';
 import {
+  AI_CONTEXT_LABELS,
+  type AiContextTarget as AiContextTargetType,
+} from '@cli/constants/ai-context';
+import {
   AddArgKind,
   AuthStrategy,
   ExtraFeature,
+  FEATURE_LABELS,
   FEATURE_PROMPT_LABELS,
 } from '@cli/constants/domain';
 import { addProjectFeatures } from '@cli/utils/add-project-features.ts';
@@ -24,15 +29,27 @@ function formatResultSummary(
     return color.dim('Nenhuma alteração necessária.');
   }
 
-  return results
-    .map((result) => {
-      if (result.installed) {
-        return `${color.green('✓')} ${result.label}`;
-      }
+  const lines = results.map((result) => {
+    if (result.installed) {
+      return `${color.green('✓')} ${result.label}`;
+    }
 
-      return `${color.yellow('○')} ${result.label} — ${result.reason ?? 'já instalado'}`;
-    })
-    .join('\n');
+    return `${color.yellow('○')} ${result.label} — ${result.reason ?? 'já instalado'}`;
+  });
+
+  const cronInstalled = results.some(
+    (result) =>
+      result.installed &&
+      result.label === FEATURE_LABELS[ExtraFeature.INTERNAL_CRON_JOBS],
+  );
+
+  if (cronInstalled) {
+    lines.push(
+      `${color.dim('Cron jobs:')} desligados — defina CRON_JOBS_ENABLED=true no .env para ligar`,
+    );
+  }
+
+  return lines.join('\n');
 }
 
 async function resolveAddArgsFromPrompt(): Promise<AddArg[]> {
@@ -55,6 +72,11 @@ async function resolveAddArgsFromPrompt(): Promise<AddArg[]> {
             label: 'OAuth2',
             hint: 'JWT + OAuth2 genérico',
           },
+          {
+            value: AuthStrategy.API_KEY,
+            label: 'API Key',
+            hint: 'aditiva (requer JWT e/ou OAuth2)',
+          },
         ].filter((option) =>
           available.authStrategies.includes(option.value as AuthStrategy),
         ),
@@ -63,7 +85,23 @@ async function resolveAddArgsFromPrompt(): Promise<AddArg[]> {
     ) as AuthStrategy[];
 
     if (authStrategies.length > 0) {
-      args.push({ kind: AddArgKind.AUTH, strategies: authStrategies });
+      let apiKeyInternalSubnet = false;
+
+      if (authStrategies.includes(AuthStrategy.API_KEY)) {
+        apiKeyInternalSubnet = assertNotCancel(
+          await p.confirm({
+            message:
+              'Incluir bypass de subnet interna (comunicação entre pods/microserviços)?',
+            initialValue: false,
+          }),
+        );
+      }
+
+      args.push({
+        kind: AddArgKind.AUTH,
+        strategies: authStrategies,
+        apiKeyInternalSubnet,
+      });
     }
   }
 
@@ -84,6 +122,23 @@ async function resolveAddArgsFromPrompt(): Promise<AddArg[]> {
     }
   }
 
+  if (available.aiContextTargets.length > 0) {
+    const targets = assertNotCancel(
+      await p.multiselect({
+        message: 'Contexto AI',
+        options: available.aiContextTargets.map((target) => ({
+          value: target,
+          label: AI_CONTEXT_LABELS[target],
+        })),
+        required: false,
+      }),
+    ) as AiContextTargetType[];
+
+    if (targets.length > 0) {
+      args.push({ kind: AddArgKind.AI_CONTEXT, targets });
+    }
+  }
+
   return dedupeAddArgs(args);
 }
 
@@ -101,7 +156,8 @@ export async function runAdd(
 
   if (
     available.authStrategies.length === 0 &&
-    available.features.length === 0
+    available.features.length === 0 &&
+    available.aiContextTargets.length === 0
   ) {
     p.outro(
       color.green(

--- a/libs/cli/commands/help.ts
+++ b/libs/cli/commands/help.ts
@@ -17,8 +17,13 @@ ${color.cyan('New — opções:')}
   ${color.dim('<nome>')}              Nome do projeto (não pergunta de novo se já informado)
   ${color.dim('--template, -t')}     ${color.dim('default')} ou ${color.dim('crud')}
   ${color.dim('--pm')}                 ${color.dim('bun')}, ${color.dim('npm')} ou ${color.dim('pnpm')}
-  ${color.dim('--auth')}               ${color.dim('none')}, ${color.dim('jwt')} ou ${color.dim('oauth2')}
+  ${color.dim('--auth')}               ${color.dim('none')}, ${color.dim('jwt')}, ${color.dim('oauth2')}, ${color.dim('api-key')} (combinações)
   ${color.dim('--features')}           ${color.dim('cache,health,cron,events')} (vírgula)
+  ${color.dim('--api-key-internal-subnet')}  Bypass de subnet interna com API Key
+
+${color.cyan('New — prompts:')}
+  Além de template/auth/features, pergunta o ${color.dim('contexto AI')} (Cursor, GitHub Copilot ou ambos).
+  Com ${color.dim('-y')} o contexto AI não é gerado (use ${color.dim('kl-nest add ai-context …')} depois).
 
 ${color.cyan('Comandos:')}
   ${color.green('new')}       Cria um novo projeto
@@ -27,11 +32,12 @@ ${color.cyan('Comandos:')}
   ${color.green('help')}      Exibe esta ajuda
 
 ${color.cyan('Add — funcionalidades:')}
-  ${color.dim('auth jwt|oauth2')}   Autenticação
-  ${color.dim('cache')}             Cache Redis (+ exemplos no CRUD)
-  ${color.dim('health')}            GET /health
-  ${color.dim('cron')}              Jobs com expressão cron
-  ${color.dim('events')}            Jobs reativos a eventos
+  ${color.dim('auth jwt|oauth2|api-key')}   Autenticação
+  ${color.dim('cache')}                     Cache Redis (+ exemplos no CRUD)
+  ${color.dim('health')}                    GET /health
+  ${color.dim('cron')}                      Jobs com expressão cron
+  ${color.dim('events')}                    Jobs reativos a eventos
+  ${color.dim('ai-context cursor|github')}  Contexto AI (AGENTS.md + regras do editor)
 
 ${color.cyan('Exemplos:')}
   kl-nest new example
@@ -41,6 +47,9 @@ ${color.cyan('Exemplos:')}
   kl-nest add cache
   kl-nest add auth jwt health --verbose
   kl-nest add cron events
+  kl-nest add ai-context cursor
+  kl-nest add ai-context github
+  kl-nest add ai-context cursor github
   kl-nest version
 `);
 }

--- a/libs/cli/commands/new/index.ts
+++ b/libs/cli/commands/new/index.ts
@@ -17,9 +17,17 @@ import {
   FEATURE_LABELS,
   FEATURE_PROMPT_LABELS,
   formatAuthStrategies,
+  assertAuthStrategiesCombination,
   Template,
   TEMPLATE_LABELS,
 } from '@cli/constants/domain';
+import {
+  AI_CONTEXT_PROMPT_LABELS,
+  AiContextPromptChoice,
+  formatAiContextTargets,
+  resolveAiContextTargetsFromPrompt,
+  type AiContextTarget,
+} from '@cli/constants/ai-context';
 import {
   installModule,
   Modules,
@@ -49,15 +57,28 @@ async function promptAuthStrategies(template: Template) {
           hint: 'JWT + OAuth2 genérico',
         },
         {
-          value: 'api-key',
+          value: AuthStrategy.API_KEY,
           label: 'API Key',
-          hint: 'em breve',
-          disabled: true,
+          hint: 'aditiva (requer JWT e/ou OAuth2)',
         },
       ],
       required: isCrud,
     }),
   ) as AuthStrategy[];
+}
+
+async function promptApiKeyInternalSubnet(strategies: AuthStrategy[]) {
+  if (!strategies.includes(AuthStrategy.API_KEY)) {
+    return false;
+  }
+
+  return assertNotCancel(
+    await p.confirm({
+      message:
+        'Incluir bypass de subnet interna (comunicação entre pods/microserviços)?',
+      initialValue: false,
+    }),
+  );
 }
 
 async function promptExtraFeatures(template: Template) {
@@ -115,6 +136,36 @@ async function promptExtraFeatures(template: Template) {
   ) as ExtraFeature[];
 }
 
+async function promptAiContext(): Promise<AiContextTarget[]> {
+  const choice = assertNotCancel(
+    await p.select({
+      message: 'Contexto AI (Cursor / GitHub Copilot)',
+      options: [
+        {
+          value: AiContextPromptChoice.NONE,
+          label: AI_CONTEXT_PROMPT_LABELS[AiContextPromptChoice.NONE],
+        },
+        {
+          value: AiContextPromptChoice.CURSOR,
+          label: AI_CONTEXT_PROMPT_LABELS[AiContextPromptChoice.CURSOR],
+          hint: '.cursor/rules + AGENTS.md',
+        },
+        {
+          value: AiContextPromptChoice.GITHUB,
+          label: AI_CONTEXT_PROMPT_LABELS[AiContextPromptChoice.GITHUB],
+          hint: '.github/copilot-instructions.md + AGENTS.md',
+        },
+        {
+          value: AiContextPromptChoice.BOTH,
+          label: AI_CONTEXT_PROMPT_LABELS[AiContextPromptChoice.BOTH],
+        },
+      ],
+    }),
+  ) as AiContextPromptChoice;
+
+  return resolveAiContextTargetsFromPrompt(choice);
+}
+
 async function promptProjectName() {
   return assertNotCancel(
     await p.text({
@@ -166,13 +217,18 @@ async function resolveProjectInput(args: string[]) {
     const packageManager =
       parsed.packageManager ?? (await promptPackageManager());
     const template = parsed.template ?? (await promptTemplate());
-    const auth =
-      parsed.auth ??
-      (await promptAuthStrategies(template));
+    const auth = parsed.auth ?? (await promptAuthStrategies(template));
+    assertAuthStrategiesCombination(auth);
+    const apiKeyInternalSubnet =
+      parsed.apiKeyInternalSubnet ||
+      (parsed.auth
+        ? parsed.apiKeyInternalSubnet
+        : await promptApiKeyInternalSubnet(auth));
     const features =
       parsed.features.length > 0
         ? parsed.features
         : await promptExtraFeatures(template);
+    const aiContext = await promptAiContext();
 
     return buildNewProjectConfig(parsed, {
       name,
@@ -180,6 +236,8 @@ async function resolveProjectInput(args: string[]) {
       template,
       auth,
       features,
+      apiKeyInternalSubnet,
+      aiContext,
     });
   }
 
@@ -195,6 +253,7 @@ async function resolveProjectInput(args: string[]) {
     template: Template.DEFAULT,
     auth: [],
     features: [],
+    aiContext: [],
   });
 }
 
@@ -243,11 +302,16 @@ export async function runNew(args: string[] = []): Promise<void> {
     template: project.template,
     auth: authStrategies,
     features,
+    apiKeyInternalSubnet: project.apiKeyInternalSubnet,
   });
 
-  spinner.message('Configurando workspace (.vscode e .env)...');
+  spinner.message('Configurando workspace (.vscode, .env e contexto AI)...');
 
-  finalizeNewProjectSetup(project.name, project.packageManager);
+  finalizeNewProjectSetup(
+    project.name,
+    project.packageManager,
+    project.aiContext,
+  );
 
   spinner.stop('Projeto criado com sucesso!');
 
@@ -272,16 +336,22 @@ export async function runNew(args: string[] = []): Promise<void> {
     .filter(Boolean)
     .join(', ');
 
-  p.note(
-    [
-      `${color.bold('Projeto:')} ${project.name}`,
-      `${color.bold('Template:')} ${TEMPLATE_LABELS[project.template]}`,
-      `${color.bold('Gerenciador:')} ${project.packageManager}`,
-      `${color.bold('Autenticação:')} ${formatAuthStrategies(authStrategies)}`,
-      `${color.bold('Extras:')} ${extrasSummary || color.dim('nenhum')}`,
-      `${color.dim('Depois:')} cd ${project.name} && ${project.packageManager} start`,
-      `${color.dim('Extras:')} kl-nest add <feature>`,
-    ].join('\n'),
-    'Resumo',
-  );
+  const summaryLines = [
+    `${color.bold('Projeto:')} ${project.name}`,
+    `${color.bold('Template:')} ${TEMPLATE_LABELS[project.template]}`,
+    `${color.bold('Gerenciador:')} ${project.packageManager}`,
+    `${color.bold('Autenticação:')} ${formatAuthStrategies(authStrategies)}`,
+    `${color.bold('Extras:')} ${extrasSummary || color.dim('nenhum')}`,
+    `${color.bold('Contexto AI:')} ${formatAiContextTargets(project.aiContext)}`,
+    `${color.dim('Depois:')} cd ${project.name} && ${project.packageManager} start`,
+    `${color.dim('Extras:')} kl-nest add <feature>`,
+  ];
+
+  if (projectFeatures.cronJobs) {
+    summaryLines.push(
+      `${color.dim('Cron jobs:')} desligados — defina CRON_JOBS_ENABLED=true no .env para ligar`,
+    );
+  }
+
+  p.note(summaryLines.join('\n'), 'Resumo');
 }

--- a/libs/cli/constants/ai-context.ts
+++ b/libs/cli/constants/ai-context.ts
@@ -1,0 +1,117 @@
+/** Alvos de scaffolding de contexto AI (Cursor / GitHub Copilot). */
+export const AiContextTarget = {
+  CURSOR: 'cursor',
+  GITHUB: 'github',
+} as const;
+
+export type AiContextTarget =
+  (typeof AiContextTarget)[keyof typeof AiContextTarget];
+
+/** Escolha do prompt interativo no `new` / `add`. */
+export const AiContextPromptChoice = {
+  NONE: 'none',
+  CURSOR: AiContextTarget.CURSOR,
+  GITHUB: AiContextTarget.GITHUB,
+  BOTH: 'both',
+} as const;
+
+export type AiContextPromptChoice =
+  (typeof AiContextPromptChoice)[keyof typeof AiContextPromptChoice];
+
+export const AI_CONTEXT_TARGETS: readonly AiContextTarget[] = [
+  AiContextTarget.CURSOR,
+  AiContextTarget.GITHUB,
+];
+
+export const AI_CONTEXT_ALIASES: Record<string, AiContextTarget> = {
+  cursor: AiContextTarget.CURSOR,
+  github: AiContextTarget.GITHUB,
+  copilot: AiContextTarget.GITHUB,
+  'github-copilot': AiContextTarget.GITHUB,
+};
+
+export const AI_CONTEXT_LABELS: Record<AiContextTarget, string> = {
+  [AiContextTarget.CURSOR]: 'Cursor (.cursor/rules + AGENTS.md)',
+  [AiContextTarget.GITHUB]:
+    'GitHub Copilot (.github/copilot-instructions.md + AGENTS.md)',
+};
+
+export const AI_CONTEXT_PROMPT_LABELS: Record<AiContextPromptChoice, string> = {
+  [AiContextPromptChoice.NONE]: 'Não configurar',
+  [AiContextPromptChoice.CURSOR]: 'Cursor',
+  [AiContextPromptChoice.GITHUB]: 'GitHub Copilot',
+  [AiContextPromptChoice.BOTH]: 'Ambos (Cursor + GitHub Copilot)',
+};
+
+/** Arquivo marcador de regras Cursor geradas pela CLI. */
+export const AI_CONTEXT_CURSOR_MARKER = '.cursor/rules/koala-layers.mdc';
+
+export const AI_CONTEXT_GITHUB_PATH = '.github/copilot-instructions.md';
+
+export const AI_CONTEXT_AGENTS_PATH = 'AGENTS.md';
+
+export const AI_CONTEXT_CURSOR_RULE_PATHS = [
+  '.cursor/rules/koala-layers.mdc',
+  '.cursor/rules/koala-application.mdc',
+  '.cursor/rules/koala-domain.mdc',
+  '.cursor/rules/koala-host.mdc',
+  '.cursor/rules/koala-class-members.mdc',
+] as const;
+
+export function isAiContextTarget(value: string): value is AiContextTarget {
+  return value === AiContextTarget.CURSOR || value === AiContextTarget.GITHUB;
+}
+
+export function parseAiContextTarget(value: string): AiContextTarget {
+  const target = AI_CONTEXT_ALIASES[value.trim().toLowerCase()];
+
+  if (!target) {
+    throw new Error(
+      `Alvo de contexto AI desconhecido: "${value}". Use: cursor, github.`,
+    );
+  }
+
+  return target;
+}
+
+export function resolveAiContextTargetsFromPrompt(
+  choice: AiContextPromptChoice,
+): AiContextTarget[] {
+  switch (choice) {
+    case AiContextPromptChoice.NONE:
+      return [];
+    case AiContextPromptChoice.CURSOR:
+      return [AiContextTarget.CURSOR];
+    case AiContextPromptChoice.GITHUB:
+      return [AiContextTarget.GITHUB];
+    case AiContextPromptChoice.BOTH:
+      return [...AI_CONTEXT_TARGETS];
+  }
+}
+
+export function formatAiContextTargets(
+  targets: readonly AiContextTarget[],
+): string {
+  if (targets.length === 0) {
+    return AiContextPromptChoice.NONE;
+  }
+
+  return targets.map((target) => AI_CONTEXT_LABELS[target]).join(' + ');
+}
+
+export function listMissingAiContextTargets(state: {
+  cursor: boolean;
+  github: boolean;
+}): AiContextTarget[] {
+  const missing: AiContextTarget[] = [];
+
+  if (!state.cursor) {
+    missing.push(AiContextTarget.CURSOR);
+  }
+
+  if (!state.github) {
+    missing.push(AiContextTarget.GITHUB);
+  }
+
+  return missing;
+}

--- a/libs/cli/constants/auth-strategy-artifacts.ts
+++ b/libs/cli/constants/auth-strategy-artifacts.ts
@@ -42,6 +42,24 @@ export const OAUTH2_INSTALL_PATHS = [
   'src/test/core/env.spec.ts',
 ] as const;
 
+/** Artefatos da estratégia API Key (aditiva a JWT/OAuth2). */
+export const API_KEY_INSTALL_PATHS = [
+  'src/application/api-key',
+  'src/host/controllers/api-key',
+  'src/domain/entities/api-key',
+  'src/domain/repositories/iapi-key.repository.ts',
+  'src/infra/repositories/api-key.repository.ts',
+  'src/infra/auth/api-key-authorization.service.ts',
+  'src/host/security/strategies/api-key.strategy.ts',
+  'src/core/utils/capture-apikey-on-request.ts',
+  'src/core/utils/match-api-key-domain-origin.ts',
+  'src/application/mapping/api-key.mapper.ts',
+  'src/infra/database/migrations/1781281330534-CreateApiKey.ts',
+] as const;
+
+export const API_KEY_SUBNET_PATH =
+  'src/core/utils/internal-subnet-validator.ts' as const;
+
 /** Removidos quando apenas OAuth2 está ativo (sem login por senha). */
 export const OAUTH2_ONLY_REMOVE_PATHS = [
   'src/application/auth/login',

--- a/libs/cli/constants/cli-project-checklist.ts
+++ b/libs/cli/constants/cli-project-checklist.ts
@@ -4,9 +4,19 @@ import {
   Template,
   resolveNewProjectOptions,
 } from '@cli/constants/domain';
+import {
+  AI_CONTEXT_AGENTS_PATH,
+  AI_CONTEXT_CURSOR_RULE_PATHS,
+  AI_CONTEXT_GITHUB_PATH,
+} from '@cli/constants/ai-context';
 import { resolveProjectFeatures } from '@cli/utils/install-module';
 
 export type CacheLevel = false | 'memory' | 'redis';
+
+export type AiContextExpectation = {
+  cursor: boolean;
+  github: boolean;
+};
 
 /** Estado esperado de um projeto gerado pela CLI (`new` / `add`). */
 export type ProjectExpectation = {
@@ -16,6 +26,7 @@ export type ProjectExpectation = {
   health: boolean;
   cronJobs: boolean;
   eventJobs: boolean;
+  aiContext?: AiContextExpectation;
 };
 
 /** Infraestrutura E2E presente em todo projeto gerado. */
@@ -44,6 +55,17 @@ export const WORKSPACE_SETUP_PATHS = [
   '.vscode/tasks.json',
   '.vscode/extensions.json',
   '.env',
+] as const;
+
+/** Contexto AI gerado pela CLI (Cursor / GitHub Copilot). */
+export const AI_CONTEXT_AGENTS_REQUIRED_PATHS = [AI_CONTEXT_AGENTS_PATH] as const;
+
+export const AI_CONTEXT_CURSOR_REQUIRED_PATHS = [
+  ...AI_CONTEXT_CURSOR_RULE_PATHS,
+] as const;
+
+export const AI_CONTEXT_GITHUB_REQUIRED_PATHS = [
+  AI_CONTEXT_GITHUB_PATH,
 ] as const;
 
 /** Núcleo comum a qualquer projeto Koala Nest. */
@@ -131,7 +153,11 @@ export const EVENTS_REQUIRED_PATHS = [
   'src/core/background-services/event-service/event-handler.base.ts',
 ] as const;
 
-export const AUTH_JWT_PACKAGES = ['@nestjs/jwt', 'passport-jwt'] as const;
+export const AUTH_JWT_PACKAGES = [
+  '@nestjs/jwt',
+  'passport-jwt',
+  'passport-custom',
+] as const;
 
 /** Combinações representativas do comando `new` para testes parametrizados. */
 export const CLI_NEW_SELECTION_MATRIX: readonly {
@@ -229,6 +255,7 @@ export function buildProjectExpectation(
   template: Template,
   auth: readonly AuthStrategy[],
   features: readonly ExtraFeature[],
+  aiContext: AiContextExpectation = { cursor: false, github: false },
 ): ProjectExpectation {
   const resolved = resolveNewProjectOptions(template, [...auth], [...features]);
   const projectFeatures = resolveProjectFeatures(
@@ -251,6 +278,7 @@ export function buildProjectExpectation(
     health: projectFeatures.health,
     cronJobs: projectFeatures.cronJobs,
     eventJobs: projectFeatures.eventJobs,
+    aiContext,
   };
 }
 
@@ -287,6 +315,20 @@ export function requiredPathsForExpectation(
     paths.push(...EVENTS_REQUIRED_PATHS);
   }
 
+  const aiContext = expectation.aiContext ?? { cursor: false, github: false };
+
+  if (aiContext.cursor || aiContext.github) {
+    paths.push(...AI_CONTEXT_AGENTS_REQUIRED_PATHS);
+  }
+
+  if (aiContext.cursor) {
+    paths.push(...AI_CONTEXT_CURSOR_REQUIRED_PATHS);
+  }
+
+  if (aiContext.github) {
+    paths.push(...AI_CONTEXT_GITHUB_REQUIRED_PATHS);
+  }
+
   return paths;
 }
 
@@ -317,6 +359,20 @@ export function forbiddenPathsForExpectation(
 
   if (!expectation.eventJobs) {
     paths.push(...EVENTS_REQUIRED_PATHS);
+  }
+
+  const aiContext = expectation.aiContext ?? { cursor: false, github: false };
+
+  if (!aiContext.cursor && !aiContext.github) {
+    paths.push(...AI_CONTEXT_AGENTS_REQUIRED_PATHS);
+  }
+
+  if (!aiContext.cursor) {
+    paths.push(...AI_CONTEXT_CURSOR_REQUIRED_PATHS);
+  }
+
+  if (!aiContext.github) {
+    paths.push(...AI_CONTEXT_GITHUB_REQUIRED_PATHS);
   }
 
   return paths;

--- a/libs/cli/constants/core-packages.ts
+++ b/libs/cli/constants/core-packages.ts
@@ -22,12 +22,13 @@ export const CORE_DEV_PACKAGES = [
 /** Redis — instalado ao selecionar Cache (Redis). */
 export const CACHE_PACKAGES = ['ioredis'] as const;
 
-/** Autenticação JWT/OAuth2. */
+/** Autenticação JWT/OAuth2/API Key. */
 export const AUTH_PACKAGES = [
   '@nestjs/jwt',
   '@nestjs/passport',
   'passport',
   'passport-jwt',
+  'passport-custom',
   'bcrypt',
 ] as const;
 

--- a/libs/cli/constants/domain.ts
+++ b/libs/cli/constants/domain.ts
@@ -11,6 +11,7 @@ export const AuthChoice = {
   NONE: 'none',
   JWT: 'jwt',
   OAUTH2: 'oauth2',
+  API_KEY: 'api-key',
 } as const;
 
 export type AuthChoice = (typeof AuthChoice)[keyof typeof AuthChoice];
@@ -19,9 +20,13 @@ export type AuthChoice = (typeof AuthChoice)[keyof typeof AuthChoice];
 export const AuthStrategy = {
   JWT: AuthChoice.JWT,
   OAUTH2: AuthChoice.OAUTH2,
+  API_KEY: AuthChoice.API_KEY,
 } as const;
 
 export type AuthStrategy = (typeof AuthStrategy)[keyof typeof AuthStrategy];
+
+export const AUTH_STRATEGY_USAGE =
+  'none, jwt, oauth2, jwt,oauth2, jwt,api-key, oauth2,api-key ou jwt,oauth2,api-key';
 
 /** Features opcionais expostas na CLI (`new` / `add`). */
 export const ExtraFeature = {
@@ -47,6 +52,7 @@ export enum InstallModule {
 export const AddArgKind = {
   AUTH: 'auth',
   FEATURE: 'feature',
+  AI_CONTEXT: 'ai-context',
 } as const;
 
 export type AddArgKind = (typeof AddArgKind)[keyof typeof AddArgKind];
@@ -117,10 +123,13 @@ export const ProjectMarker = {
   PERSON_MODULE: 'PersonModule',
   SECURITY_MODULE: 'SecurityModule',
   AUTH_MODULE: 'AuthModule',
+  API_KEY_MODULE: 'ApiKeyModule',
+  API_KEY_STRATEGY: 'ApiKeyStrategy',
   HEALTH_CHECK_MODULE: 'HealthCheckModule',
   CACHE_SERVICE_PROVIDER: 'CacheServiceProvider',
   OAUTH_AUTH_LINK_HANDLER: 'OAuthAuthLinkHandler',
   REDIS_INDICATOR: 'RedisIndicator',
+  INTERNAL_SUBNET_VALIDATOR: 'InternalSubnetValidator',
 } as const;
 
 export const DDD_LAYER_FOLDERS = [
@@ -151,12 +160,31 @@ export function isAuthChoice(value: string): value is AuthChoice {
   return (
     value === AuthChoice.NONE ||
     value === AuthChoice.JWT ||
-    value === AuthChoice.OAUTH2
+    value === AuthChoice.OAUTH2 ||
+    value === AuthChoice.API_KEY
   );
 }
 
 export function isAuthStrategy(value: string): value is AuthStrategy {
-  return value === AuthStrategy.JWT || value === AuthStrategy.OAUTH2;
+  return (
+    value === AuthStrategy.JWT ||
+    value === AuthStrategy.OAUTH2 ||
+    value === AuthStrategy.API_KEY
+  );
+}
+
+export function assertAuthStrategiesCombination(
+  strategies: readonly AuthStrategy[],
+) {
+  if (
+    strategies.includes(AuthStrategy.API_KEY) &&
+    !strategies.includes(AuthStrategy.JWT) &&
+    !strategies.includes(AuthStrategy.OAUTH2)
+  ) {
+    throw new Error(
+      `API Key é aditiva e não pode ser usada sozinha. Use: jwt,api-key, oauth2,api-key ou jwt,oauth2,api-key.`,
+    );
+  }
 }
 
 export function parseAuthStrategies(
@@ -168,7 +196,7 @@ export function parseAuthStrategies(
   if (normalized === AuthChoice.NONE || normalized === '') {
     if (template === Template.CRUD_SAMPLE) {
       throw new Error(
-        'Template CRUD exige autenticação. Use: --auth jwt, --auth oauth2 ou --auth jwt,oauth2.',
+        `Template CRUD exige autenticação. Use: --auth jwt, --auth oauth2, --auth jwt,oauth2 ou com api-key (${AUTH_STRATEGY_USAGE}).`,
       );
     }
 
@@ -185,11 +213,13 @@ export function parseAuthStrategies(
       }
 
       throw new Error(
-        `Autenticação desconhecida: "${item}". Use: none, jwt, oauth2 ou jwt,oauth2.`,
+        `Autenticação desconhecida: "${item}". Use: ${AUTH_STRATEGY_USAGE}.`,
       );
     });
 
-  return Array.from(new Set(strategies));
+  const unique = Array.from(new Set(strategies));
+  assertAuthStrategiesCombination(unique);
+  return unique;
 }
 
 export function formatAuthStrategies(strategies: readonly AuthStrategy[]): string {
@@ -202,6 +232,7 @@ export function formatAuthStrategies(strategies: readonly AuthStrategy[]): strin
 
 export function resolveAuthStrategiesFromModule(
   authModuleSource: string,
+  extras?: { appModuleSource?: string; securityModuleSource?: string },
 ): AuthStrategy[] {
   const strategies: AuthStrategy[] = [];
 
@@ -211,6 +242,14 @@ export function resolveAuthStrategiesFromModule(
 
   if (authModuleSource.includes(ProjectMarker.OAUTH_AUTH_LINK_HANDLER)) {
     strategies.push(AuthStrategy.OAUTH2);
+  }
+
+  const hasApiKey =
+    extras?.appModuleSource?.includes(ProjectMarker.API_KEY_MODULE) ||
+    extras?.securityModuleSource?.includes(ProjectMarker.API_KEY_STRATEGY);
+
+  if (hasApiKey) {
+    strategies.push(AuthStrategy.API_KEY);
   }
 
   return strategies;
@@ -237,7 +276,7 @@ export function listMissingAuthStrategies(
 ): AuthStrategy[] {
   const current = installed === false ? [] : installed;
 
-  return [AuthStrategy.JWT, AuthStrategy.OAUTH2].filter(
+  return [AuthStrategy.JWT, AuthStrategy.OAUTH2, AuthStrategy.API_KEY].filter(
     (strategy) => !current.includes(strategy),
   );
 }

--- a/libs/cli/test/isolated-mocks/add-project-features.spec.ts
+++ b/libs/cli/test/isolated-mocks/add-project-features.spec.ts
@@ -229,7 +229,7 @@ export class AppModule {}
     expect(results).toEqual([{ label: 'auth (oauth2)', installed: true }]);
     expect(installCalls).toHaveLength(0);
     expect(patchAuthCalls).toEqual([
-      ['.', ['jwt', 'oauth2']],
+      ['.', ['jwt', 'oauth2'], { apiKeyInternalSubnet: undefined }],
     ]);
   });
 

--- a/libs/cli/test/unit/add-command.spec.ts
+++ b/libs/cli/test/unit/add-command.spec.ts
@@ -141,19 +141,39 @@ describe('parseAddArgs', () => {
 
   it('aceita auth com estratégia', () => {
     expect(parseAddArgs(['auth', 'oauth2', 'cache'])).toEqual([
-      { kind: 'auth', strategies: ['oauth2'] },
+      { kind: 'auth', strategies: ['oauth2'], apiKeyInternalSubnet: false },
       { kind: 'feature', feature: 'cache' },
     ]);
   });
 
   it('aceita múltiplas estratégias de auth', () => {
     expect(parseAddArgs(['auth', 'jwt', 'oauth2'])).toEqual([
-      { kind: 'auth', strategies: ['jwt', 'oauth2'] },
+      {
+        kind: 'auth',
+        strategies: ['jwt', 'oauth2'],
+        apiKeyInternalSubnet: false,
+      },
     ]);
   });
 
   it('rejeita auth sem estratégia', () => {
     expect(() => parseAddArgs(['auth'])).toThrow(/auth jwt/);
+  });
+
+  it('aceita ai-context com alvos', () => {
+    expect(parseAddArgs(['ai-context', 'cursor', 'github'])).toEqual([
+      { kind: 'ai-context', targets: ['cursor', 'github'] },
+    ]);
+  });
+
+  it('aceita alias copilot para github', () => {
+    expect(parseAddArgs(['ai-context', 'copilot'])).toEqual([
+      { kind: 'ai-context', targets: ['github'] },
+    ]);
+  });
+
+  it('rejeita ai-context sem alvos', () => {
+    expect(() => parseAddArgs(['ai-context'])).toThrow(/ai-context cursor/);
   });
 });
 
@@ -165,10 +185,17 @@ describe('dedupeAddArgs', () => {
         { kind: 'feature', feature: 'cache' },
         { kind: 'auth', strategies: ['jwt'] },
         { kind: 'auth', strategies: ['oauth2'] },
+        { kind: 'ai-context', targets: ['cursor'] },
+        { kind: 'ai-context', targets: ['github', 'cursor'] },
       ]),
     ).toEqual([
-      { kind: 'auth', strategies: ['jwt', 'oauth2'] },
+      {
+        kind: 'auth',
+        strategies: ['jwt', 'oauth2'],
+        apiKeyInternalSubnet: false,
+      },
       { kind: 'feature', feature: 'cache' },
+      { kind: 'ai-context', targets: ['cursor', 'github'] },
     ]);
   });
 });
@@ -195,6 +222,7 @@ describe('detectProjectState', () => {
         health: true,
         cronJobs: true,
         eventJobs: true,
+        aiContext: { cursor: false, github: false },
       });
     } finally {
       process.chdir(previousCwd);

--- a/libs/cli/test/unit/auth-domain.spec.ts
+++ b/libs/cli/test/unit/auth-domain.spec.ts
@@ -14,17 +14,25 @@ describe('parseAuthStrategies', () => {
     expect(parseAuthStrategies('', Template.DEFAULT)).toEqual([]);
   });
 
-  it('aceita jwt, oauth2 e combinações deduplicadas', () => {
+  it('aceita jwt, oauth2, api-key aditiva e combinações deduplicadas', () => {
     expect(parseAuthStrategies('jwt')).toEqual([AuthStrategy.JWT]);
     expect(parseAuthStrategies('oauth2')).toEqual([AuthStrategy.OAUTH2]);
     expect(parseAuthStrategies('jwt,oauth2')).toEqual([
       AuthStrategy.JWT,
       AuthStrategy.OAUTH2,
     ]);
+    expect(parseAuthStrategies('jwt,api-key')).toEqual([
+      AuthStrategy.JWT,
+      AuthStrategy.API_KEY,
+    ]);
     expect(parseAuthStrategies('oauth2,jwt,oauth2')).toEqual([
       AuthStrategy.OAUTH2,
       AuthStrategy.JWT,
     ]);
+  });
+
+  it('rejeita api-key sozinha', () => {
+    expect(() => parseAuthStrategies('api-key')).toThrow(/aditiva/);
   });
 
   it('rejeita auth none no template CRUD', () => {
@@ -57,30 +65,43 @@ describe('listMissingAuthStrategies', () => {
     expect(listMissingAuthStrategies(false)).toEqual([
       AuthStrategy.JWT,
       AuthStrategy.OAUTH2,
+      AuthStrategy.API_KEY,
     ]);
   });
 
-  it('lista apenas oauth2 quando jwt já está instalado', () => {
+  it('lista oauth2 e api-key quando jwt já está instalado', () => {
     expect(listMissingAuthStrategies([AuthStrategy.JWT])).toEqual([
       AuthStrategy.OAUTH2,
+      AuthStrategy.API_KEY,
     ]);
   });
 
-  it('lista apenas jwt quando oauth2 já está instalado', () => {
+  it('lista jwt e api-key quando oauth2 já está instalado', () => {
     expect(listMissingAuthStrategies([AuthStrategy.OAUTH2])).toEqual([
       AuthStrategy.JWT,
+      AuthStrategy.API_KEY,
     ]);
   });
 
-  it('retorna vazio quando ambas estão instaladas', () => {
+  it('lista apenas api-key quando jwt e oauth2 estão instalados', () => {
     expect(
       listMissingAuthStrategies([AuthStrategy.JWT, AuthStrategy.OAUTH2]),
+    ).toEqual([AuthStrategy.API_KEY]);
+  });
+
+  it('retorna vazio quando todas estão instaladas', () => {
+    expect(
+      listMissingAuthStrategies([
+        AuthStrategy.JWT,
+        AuthStrategy.OAUTH2,
+        AuthStrategy.API_KEY,
+      ]),
     ).toEqual([]);
   });
 });
 
 describe('resolveAuthStrategiesFromModule', () => {
-  it('detecta jwt, oauth2 ou ambos pelo auth.module.ts', () => {
+  it('detecta jwt, oauth2, api-key ou combinações', () => {
     expect(
       resolveAuthStrategiesFromModule('export class LoginController {}'),
     ).toEqual([AuthStrategy.JWT]);
@@ -94,6 +115,11 @@ describe('resolveAuthStrategiesFromModule', () => {
         'LoginController\nOAuthAuthLinkHandler',
       ),
     ).toEqual([AuthStrategy.JWT, AuthStrategy.OAUTH2]);
+    expect(
+      resolveAuthStrategiesFromModule('LoginController', {
+        appModuleSource: 'ApiKeyModule',
+      }),
+    ).toEqual([AuthStrategy.JWT, AuthStrategy.API_KEY]);
     expect(resolveAuthStrategiesFromModule('export class AuthModule {}')).toEqual(
       [],
     );

--- a/libs/cli/test/unit/auth-strategies.spec.ts
+++ b/libs/cli/test/unit/auth-strategies.spec.ts
@@ -13,6 +13,7 @@ import {
   assertAuthStrategyPaths,
   installAuthArtifactsForStrategies,
   pruneAuthArtifactsForStrategies,
+  stripApiKeyFromRepositoryModule,
 } from '@cli/utils/prune-auth-strategies.ts';
 import { getSourceCodePath } from '@cli/utils/get-source-code-path.ts';
 
@@ -68,6 +69,43 @@ describe('patchSecurityModuleForJwt', () => {
     expect(content).not.toContain('IOAuth2Service');
     expect(content).not.toContain('OAuthProviderRegistry');
     expect(content).not.toContain('OAuth2AuthService');
+  });
+});
+
+describe('stripApiKeyFromRepositoryModule', () => {
+  it('remove IApiKeyRepository de providers e exports multilinha', () => {
+    const content = `import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { IPersonRepository } from '@/domain/repositories/iperson.repository';
+import { IUserRepository } from '@/domain/repositories/iuser.repository';
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@/infra/database/database.module';
+import { ApiKeyRepository } from '@/infra/repositories/api-key.repository';
+import { PersonRepository } from '@/infra/repositories/person.repository';
+import { UserRepository } from '@/infra/repositories/user.repository';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [
+    { provide: IPersonRepository, useClass: PersonRepository },
+    { provide: IUserRepository, useClass: UserRepository },
+    { provide: IApiKeyRepository, useClass: ApiKeyRepository },
+  ],
+  exports: [
+    DatabaseModule,
+    IPersonRepository,
+    IUserRepository,
+    IApiKeyRepository,
+  ],
+})
+export class RepositoryModule {}
+`;
+
+    const patched = stripApiKeyFromRepositoryModule(content);
+
+    expect(patched).not.toContain('IApiKeyRepository');
+    expect(patched).not.toContain('ApiKeyRepository');
+    expect(patched).toContain('IUserRepository');
+    expect(patched).toContain('IPersonRepository');
   });
 });
 

--- a/libs/cli/test/unit/cli-project-checklist.spec.ts
+++ b/libs/cli/test/unit/cli-project-checklist.spec.ts
@@ -23,6 +23,7 @@ describe('cli-project-checklist', () => {
       health: false,
       cronJobs: true,
       eventJobs: true,
+      aiContext: { cursor: false, github: false },
     });
   });
 
@@ -34,7 +35,21 @@ describe('cli-project-checklist', () => {
       cache: 'redis',
       cronJobs: true,
       eventJobs: true,
+      aiContext: { cursor: false, github: false },
     });
+  });
+
+  it('requiredPaths inclui contexto AI quando solicitado', () => {
+    const paths = requiredPathsForExpectation(
+      buildProjectExpectation(Template.DEFAULT, [], [], {
+        cursor: true,
+        github: true,
+      }),
+    );
+
+    expect(paths).toContain('AGENTS.md');
+    expect(paths).toContain('.cursor/rules/koala-layers.mdc');
+    expect(paths).toContain('.github/copilot-instructions.md');
   });
 
   it('buildProjectExpectation usa cache em memória para auth sem Redis', () => {

--- a/libs/cli/test/unit/install-ai-context.spec.ts
+++ b/libs/cli/test/unit/install-ai-context.spec.ts
@@ -1,0 +1,111 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { AiContextTarget } from '@cli/constants/ai-context';
+import { installAiContext } from '@cli/utils/install-ai-context.ts';
+
+describe('installAiContext', () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  function createProject() {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-ai-context-'));
+    const projectDir = path.join(tempDir, 'my-api');
+    mkdirSync(projectDir, { recursive: true });
+    return projectDir;
+  }
+
+  it('instala cursor com AGENTS.md e regras .cursor', () => {
+    const projectDir = createProject();
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      const results = installAiContext('my-api', [AiContextTarget.CURSOR]);
+
+      expect(results).toEqual([
+        {
+          label: 'Cursor (.cursor/rules + AGENTS.md)',
+          installed: true,
+          reason: undefined,
+        },
+      ]);
+      expect(existsSync(path.join(projectDir, 'AGENTS.md'))).toBe(true);
+      expect(
+        existsSync(path.join(projectDir, '.cursor/rules/koala-layers.mdc')),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(projectDir, '.github/copilot-instructions.md')),
+      ).toBe(false);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('instala github com AGENTS.md e copilot-instructions', () => {
+    const projectDir = createProject();
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      installAiContext('my-api', [AiContextTarget.GITHUB]);
+
+      expect(existsSync(path.join(projectDir, 'AGENTS.md'))).toBe(true);
+      expect(
+        existsSync(path.join(projectDir, '.github/copilot-instructions.md')),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(projectDir, '.cursor/rules/koala-layers.mdc')),
+      ).toBe(false);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('não sobrescreve AGENTS.md existente', () => {
+    const projectDir = createProject();
+    writeFileSync(path.join(projectDir, 'AGENTS.md'), '# custom\n');
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      installAiContext('my-api', [AiContextTarget.CURSOR]);
+
+      expect(readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf8')).toBe(
+        '# custom\n',
+      );
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('é idempotente quando regras já existem', () => {
+    createProject();
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      installAiContext('my-api', [AiContextTarget.CURSOR]);
+      const second = installAiContext('my-api', [AiContextTarget.CURSOR]);
+
+      expect(second[0]?.installed).toBe(false);
+      expect(second[0]?.reason).toMatch(/já estão instaladas/);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});

--- a/libs/cli/test/unit/install-workspace-config.spec.ts
+++ b/libs/cli/test/unit/install-workspace-config.spec.ts
@@ -96,4 +96,37 @@ describe('install-workspace-config', () => {
       expected,
     );
   });
+
+  it('preenche chaves JWT vazias no .env ao copiar do .env.example', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-workspace-jwt-'));
+    const projectDir = path.join(tempDir, 'my-api');
+    mkdirSync(projectDir, { recursive: true });
+
+    writeFileSync(
+      path.join(projectDir, '.env.example'),
+      'PORT=3000\nDATABASE_URL=postgresql://postgres:root@localhost:5432/koala_nest\nJWT_PRIVATE_KEY=\nJWT_PUBLIC_KEY=\n',
+    );
+
+    const previousCwd = process.cwd();
+
+    try {
+      process.chdir(tempDir);
+      createEnvFromExample('my-api');
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const env = readFileSync(path.join(projectDir, '.env'), 'utf8');
+    const example = readFileSync(path.join(projectDir, '.env.example'), 'utf8');
+
+    expect(env).toContain('DATABASE_URL=postgresql://postgres:root@localhost:5432/my_api');
+    expect(env.match(/^JWT_PRIVATE_KEY=(.+)$/m)?.[1]?.length).toBeGreaterThan(
+      100,
+    );
+    expect(env.match(/^JWT_PUBLIC_KEY=(.+)$/m)?.[1]?.length).toBeGreaterThan(
+      100,
+    );
+    expect(example).toMatch(/^JWT_PRIVATE_KEY=$/m);
+    expect(example).toMatch(/^JWT_PUBLIC_KEY=$/m);
+  });
 });

--- a/libs/cli/test/unit/normalize-add-args.spec.ts
+++ b/libs/cli/test/unit/normalize-add-args.spec.ts
@@ -43,4 +43,18 @@ describe('normalizeAddArgs', () => {
       { kind: 'feature', feature: 'internal-event-jobs' },
     ]);
   });
+
+  it('coloca ai-context no final', () => {
+    expect(
+      normalizeAddArgs([
+        { kind: 'ai-context', targets: ['cursor'] },
+        { kind: 'feature', feature: 'cache' },
+        { kind: 'auth', strategies: ['jwt'] },
+      ]),
+    ).toEqual([
+      { kind: 'feature', feature: 'cache' },
+      { kind: 'auth', strategies: ['jwt'] },
+      { kind: 'ai-context', targets: ['cursor'] },
+    ]);
+  });
 });

--- a/libs/cli/test/unit/parse-new-args.spec.ts
+++ b/libs/cli/test/unit/parse-new-args.spec.ts
@@ -9,6 +9,8 @@ describe('parseNewArgs', () => {
       template: undefined,
       auth: undefined,
       features: [],
+      aiContext: [],
+      apiKeyInternalSubnet: false,
       yes: false,
       interactive: true,
     });
@@ -21,6 +23,8 @@ describe('parseNewArgs', () => {
       template: 'default',
       auth: undefined,
       features: [],
+      aiContext: [],
+      apiKeyInternalSubnet: false,
       yes: false,
       interactive: true,
     });
@@ -44,6 +48,8 @@ describe('parseNewArgs', () => {
       template: 'default',
       auth: [],
       features: [],
+      aiContext: [],
+      apiKeyInternalSubnet: false,
       yes: true,
       interactive: false,
     });

--- a/libs/cli/test/unit/patch-env.spec.ts
+++ b/libs/cli/test/unit/patch-env.spec.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { AuthStrategy } from '@cli/constants/domain';
-import { patchEnvForAuthStrategies } from '@cli/utils/patch-env.ts';
+import {
+  ensureJwtKeysInEnv,
+  patchEnvForAuthStrategies,
+} from '@cli/utils/patch-env.ts';
 
 describe('patchEnvForAuthStrategies', () => {
   let tempDir = '';
@@ -62,5 +65,101 @@ describe('patchEnvForAuthStrategies', () => {
 
     expect(envExample).toContain('JWT_PRIVATE_KEY');
     expect(envExample).toContain('OAUTH2_PROVIDERS');
+  });
+
+  it('gera JWT_PRIVATE_KEY e JWT_PUBLIC_KEY no .env quando vazias', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-patch-env-keys-'));
+    writeFileSync(
+      path.join(tempDir, '.env'),
+      'PORT=3000\nJWT_PRIVATE_KEY=\nJWT_PUBLIC_KEY=\n',
+    );
+
+    patchEnvForAuthStrategies(tempDir, [AuthStrategy.JWT]);
+
+    const env = readFileSync(path.join(tempDir, '.env'), 'utf8');
+    const envExample = readFileSync(
+      path.join(tempDir, '.env.example'),
+      'utf8',
+    );
+    const privateMatch = env.match(/^JWT_PRIVATE_KEY=(.+)$/m);
+    const publicMatch = env.match(/^JWT_PUBLIC_KEY=(.+)$/m);
+
+    expect(privateMatch?.[1]?.length).toBeGreaterThan(100);
+    expect(publicMatch?.[1]?.length).toBeGreaterThan(100);
+    expect(envExample).toMatch(/^JWT_PRIVATE_KEY=$/m);
+    expect(envExample).toMatch(/^JWT_PUBLIC_KEY=$/m);
+  });
+
+  it('não sobrescreve chaves JWT já preenchidas no .env', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-patch-env-keep-'));
+    writeFileSync(
+      path.join(tempDir, '.env'),
+      'JWT_PRIVATE_KEY=existing-private\nJWT_PUBLIC_KEY=existing-public\n',
+    );
+
+    patchEnvForAuthStrategies(tempDir, [AuthStrategy.JWT]);
+
+    const env = readFileSync(path.join(tempDir, '.env'), 'utf8');
+
+    expect(env).toContain('JWT_PRIVATE_KEY=existing-private');
+    expect(env).toContain('JWT_PUBLIC_KEY=existing-public');
+  });
+
+  it('com API Key adiciona e gera chaves JWT no .env se ausentes', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-patch-env-apikey-'));
+    writeFileSync(path.join(tempDir, '.env'), 'PORT=3000\n');
+
+    patchEnvForAuthStrategies(tempDir, [
+      AuthStrategy.JWT,
+      AuthStrategy.API_KEY,
+    ]);
+
+    const env = readFileSync(path.join(tempDir, '.env'), 'utf8');
+    const privateMatch = env.match(/^JWT_PRIVATE_KEY=(.+)$/m);
+    const publicMatch = env.match(/^JWT_PUBLIC_KEY=(.+)$/m);
+
+    expect(privateMatch?.[1]?.length).toBeGreaterThan(100);
+    expect(publicMatch?.[1]?.length).toBeGreaterThan(100);
+  });
+});
+
+describe('ensureJwtKeysInEnv', () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  it('sem addIfMissing não cria chaves quando o .env não tem JWT_*', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-ensure-jwt-skip-'));
+    writeFileSync(path.join(tempDir, '.env'), 'PORT=3000\n');
+
+    expect(ensureJwtKeysInEnv(tempDir)).toBe(false);
+    expect(readFileSync(path.join(tempDir, '.env'), 'utf8')).toBe('PORT=3000\n');
+  });
+
+  it('preenche chaves vazias sem alterar .env.example', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'koala-ensure-jwt-fill-'));
+    writeFileSync(
+      path.join(tempDir, '.env'),
+      'JWT_PRIVATE_KEY=\nJWT_PUBLIC_KEY=\n',
+    );
+    writeFileSync(
+      path.join(tempDir, '.env.example'),
+      'JWT_PRIVATE_KEY=\nJWT_PUBLIC_KEY=\n',
+    );
+
+    expect(ensureJwtKeysInEnv(tempDir)).toBe(true);
+
+    const env = readFileSync(path.join(tempDir, '.env'), 'utf8');
+    const example = readFileSync(path.join(tempDir, '.env.example'), 'utf8');
+
+    expect(env.match(/^JWT_PRIVATE_KEY=(.+)$/m)?.[1]?.length).toBeGreaterThan(
+      100,
+    );
+    expect(example).toBe('JWT_PRIVATE_KEY=\nJWT_PUBLIC_KEY=\n');
   });
 });

--- a/libs/cli/test/unit/remove-sample-parts.spec.ts
+++ b/libs/cli/test/unit/remove-sample-parts.spec.ts
@@ -32,20 +32,17 @@ describe('removeSampleParts', () => {
     mkdirSync(path.join(srcDir, 'application/mapping'), { recursive: true });
     mkdirSync(path.join(srcDir, 'test/application'), { recursive: true });
 
-    const repoRoot = process.cwd();
+    const templateRepositoryModule = path.resolve(
+      import.meta.dir,
+      '../../../koala-nest/src/infra/repositories/repository.module.ts',
+    );
     writeFileSync(
       path.join(srcDir, 'host/app.module.ts'),
       `import { PersonModule } from './controllers/person/person.module';\n@Module({ imports: [PersonModule,\n] })`,
     );
     writeFileSync(
       path.join(srcDir, 'infra/repositories/repository.module.ts'),
-      readFileSync(
-        path.join(
-          repoRoot,
-          'libs/koala-nest/src/infra/repositories/repository.module.ts',
-        ),
-        'utf8',
-      ),
+      readFileSync(templateRepositoryModule, 'utf8'),
     );
     writeFileSync(
       path.join(srcDir, 'application/mapping/mapping.provider.ts'),

--- a/libs/cli/test/unit/remove-sample-parts.spec.ts
+++ b/libs/cli/test/unit/remove-sample-parts.spec.ts
@@ -32,13 +32,20 @@ describe('removeSampleParts', () => {
     mkdirSync(path.join(srcDir, 'application/mapping'), { recursive: true });
     mkdirSync(path.join(srcDir, 'test/application'), { recursive: true });
 
+    const repoRoot = process.cwd();
     writeFileSync(
       path.join(srcDir, 'host/app.module.ts'),
       `import { PersonModule } from './controllers/person/person.module';\n@Module({ imports: [PersonModule,\n] })`,
     );
     writeFileSync(
       path.join(srcDir, 'infra/repositories/repository.module.ts'),
-      `import { IPersonRepository } from '@/domain/repositories/iperson.repository';\nimport { PersonRepository } from '@/infra/repositories/person.repository';\nproviders: [{ provide: IPersonRepository, useClass: PersonRepository }],\nexports: [DatabaseModule, IPersonRepository],`,
+      readFileSync(
+        path.join(
+          repoRoot,
+          'libs/koala-nest/src/infra/repositories/repository.module.ts',
+        ),
+        'utf8',
+      ),
     );
     writeFileSync(
       path.join(srcDir, 'application/mapping/mapping.provider.ts'),
@@ -60,18 +67,15 @@ describe('removeSampleParts', () => {
         'utf8',
       );
       expect(appModule).not.toContain('PersonModule');
-      expect(
-        readFileSync(
-          path.join(srcDir, 'infra/repositories/repository.module.ts'),
-          'utf8',
-        ),
-      ).not.toContain('IPersonRepository');
-      expect(
-        readFileSync(
-          path.join(srcDir, 'infra/repositories/repository.module.ts'),
-          'utf8',
-        ),
-      ).not.toContain('PersonRepository');
+      const repositoryModule = readFileSync(
+        path.join(srcDir, 'infra/repositories/repository.module.ts'),
+        'utf8',
+      );
+      expect(repositoryModule).not.toContain('IPersonRepository');
+      expect(repositoryModule).not.toContain('PersonRepository');
+      expect(repositoryModule).not.toContain('IUserRepository');
+      expect(repositoryModule).not.toContain('IApiKeyRepository');
+      expect(repositoryModule).toContain('exports: [DatabaseModule]');
     } finally {
       process.chdir(previousCwd);
     }

--- a/libs/cli/utils/add-project-features.ts
+++ b/libs/cli/utils/add-project-features.ts
@@ -4,6 +4,7 @@ import {
   ExtraFeature,
   FEATURE_LABELS,
   formatAuthStrategies,
+  assertAuthStrategiesCombination,
   mergeAuthStrategies,
   Template,
 } from '@cli/constants/domain';
@@ -32,6 +33,8 @@ import {
 import { normalizeAddArgs } from './normalize-add-args';
 import { restoreRedisHealthCheck } from './patch-health-module';
 import { patchAuthInstall } from './patch-auth-install';
+import { installAiContext } from './install-ai-context';
+import { AiContextTarget } from '@cli/constants/ai-context';
 
 async function ensureMemoryCache(projectName: string, template: TemplateType) {
   const state = detectProjectState(projectName);
@@ -94,6 +97,30 @@ export async function addProjectFeatures(
   const orderedArgs = normalizeAddArgs(args);
 
   for (const arg of orderedArgs) {
+    if (arg.kind === AddArgKind.AI_CONTEXT) {
+      const missing = arg.targets.filter((target) => {
+        if (target === AiContextTarget.CURSOR) {
+          return !state.aiContext.cursor;
+        }
+
+        return !state.aiContext.github;
+      });
+
+      if (missing.length === 0) {
+        results.push({
+          label: 'contexto AI',
+          installed: false,
+          reason: 'Contexto AI solicitado já está instalado.',
+        });
+        continue;
+      }
+
+      const contextResults = installAiContext(projectName, missing);
+      results.push(...contextResults);
+      state = detectProjectState(projectName);
+      continue;
+    }
+
     if (arg.kind === AddArgKind.AUTH) {
       const current = state.auth === false ? [] : state.auth;
       const missing = arg.strategies.filter(
@@ -110,19 +137,23 @@ export async function addProjectFeatures(
       }
 
       const next = mergeAuthStrategies(current, missing);
+      assertAuthStrategiesCombination(next);
 
       if (current.length === 0) {
         await ensureMemoryCache(projectName, template);
 
         await installModule(Modules.AUTH, template, projectName, {
           authStrategies: next,
+          apiKeyInternalSubnet: arg.apiKeyInternalSubnet,
         });
 
         if (template === Template.CRUD_SAMPLE) {
           await restorePersonAuthExample(projectName);
         }
       } else {
-        await patchAuthInstall(projectName, next);
+        await patchAuthInstall(projectName, next, {
+          apiKeyInternalSubnet: arg.apiKeyInternalSubnet,
+        });
       }
 
       results.push({

--- a/libs/cli/utils/apply-optional-features.ts
+++ b/libs/cli/utils/apply-optional-features.ts
@@ -14,6 +14,7 @@ export type ApplyOptionalFeaturesOptions = {
   template: Template;
   auth: AuthStrategy[];
   features: ExtraFeature[];
+  apiKeyInternalSubnet?: boolean;
   skipPackages?: boolean;
 };
 
@@ -45,6 +46,7 @@ export async function applyOptionalFeatures(
   if (options.auth.length > 0) {
     await installModule(Modules.AUTH, options.template, projectName, {
       authStrategies: options.auth,
+      apiKeyInternalSubnet: options.apiKeyInternalSubnet,
       skipPackages: options.skipPackages,
     });
   }

--- a/libs/cli/utils/cli-project-validation.ts
+++ b/libs/cli/utils/cli-project-validation.ts
@@ -229,6 +229,23 @@ export function listCliProjectViolations(
       );
     }
 
+    const expectedAi = expectation.aiContext ?? {
+      cursor: false,
+      github: false,
+    };
+
+    if (detected.aiContext.cursor !== expectedAi.cursor) {
+      violations.push(
+        `state:aiContext.cursor esperado ${expectedAi.cursor}, detectado ${detected.aiContext.cursor}`,
+      );
+    }
+
+    if (detected.aiContext.github !== expectedAi.github) {
+      violations.push(
+        `state:aiContext.github esperado ${expectedAi.github}, detectado ${detected.aiContext.github}`,
+      );
+    }
+
     const expectedAuth =
       expectation.auth === false
         ? false

--- a/libs/cli/utils/detect-project-state.ts
+++ b/libs/cli/utils/detect-project-state.ts
@@ -1,7 +1,15 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
+  AI_CONTEXT_CURSOR_MARKER,
+  AI_CONTEXT_GITHUB_PATH,
+  listMissingAiContextTargets,
+  parseAiContextTarget,
+  type AiContextTarget as AiContextTargetType,
+} from '@cli/constants/ai-context';
+import {
   AddArgKind,
+  AuthStrategy,
   ExtraFeature,
   FEATURE_ALIASES,
   isAuthStrategy,
@@ -16,6 +24,11 @@ import { resolveProjectPath } from './resolve-project-path';
 
 export type CacheLevel = false | 'memory' | 'redis';
 
+export type AiContextState = {
+  cursor: boolean;
+  github: boolean;
+};
+
 export type ProjectState = {
   template: Template;
   auth: false | AuthStrategyType[];
@@ -23,6 +36,7 @@ export type ProjectState = {
   health: boolean;
   cronJobs: boolean;
   eventJobs: boolean;
+  aiContext: AiContextState;
 };
 
 export function assertKoalaProject(projectName = ''): string {
@@ -72,7 +86,18 @@ export function detectProjectState(projectName = ''): ProjectState {
     existsSync(authModulePath) &&
     appModule.includes(ProjectMarker.SECURITY_MODULE)
   ) {
-    auth = resolveAuthStrategiesFromModule(authModule);
+    const securityModulePath = path.join(
+      resolveProjectPath(projectName),
+      'src/host/security/security.module.ts',
+    );
+    const securityModule = existsSync(securityModulePath)
+      ? readFileSync(securityModulePath, 'utf8')
+      : '';
+
+    auth = resolveAuthStrategiesFromModule(authModule, {
+      appModuleSource: appModule,
+      securityModuleSource: securityModule,
+    });
   }
 
   let cache: CacheLevel = false;
@@ -89,23 +114,26 @@ export function detectProjectState(projectName = ''): ProjectState {
     cache = hasRedisFile ? 'redis' : 'memory';
   }
 
+  const projectRoot = resolveProjectPath(projectName);
+
   return {
     template: hasPersonModule ? Template.CRUD_SAMPLE : Template.DEFAULT,
     auth,
     cache,
     health: appModule.includes(ProjectMarker.HEALTH_CHECK_MODULE),
     cronJobs: existsSync(
-      path.join(
-        resolveProjectPath(projectName),
-        'src/core/utils/cron-expression-to-boolean.ts',
-      ),
+      path.join(projectRoot, 'src/core/utils/cron-expression-to-boolean.ts'),
     ),
     eventJobs: existsSync(
       path.join(
-        resolveProjectPath(projectName),
+        projectRoot,
         'src/core/background-services/event-service/event-handler.base.ts',
       ),
     ),
+    aiContext: {
+      cursor: existsSync(path.join(projectRoot, AI_CONTEXT_CURSOR_MARKER)),
+      github: existsSync(path.join(projectRoot, AI_CONTEXT_GITHUB_PATH)),
+    },
   };
 }
 
@@ -128,15 +156,36 @@ export function listAvailableAddOptions(state: ProjectState) {
     features.push(ExtraFeature.INTERNAL_EVENT_JOBS);
   }
 
+  const missing = listMissingAuthStrategies(state.auth);
+  const installed = state.auth === false ? [] : state.auth;
+  const hasHumanAuth =
+    installed.includes(AuthStrategy.JWT) ||
+    installed.includes(AuthStrategy.OAUTH2);
+
   return {
-    authStrategies: listMissingAuthStrategies(state.auth),
+    authStrategies: missing.filter((strategy) => {
+      if (strategy !== AuthStrategy.API_KEY) {
+        return true;
+      }
+
+      return hasHumanAuth;
+    }),
     features,
+    aiContextTargets: listMissingAiContextTargets(state.aiContext),
   };
 }
 
 export type AddArg =
-  | { kind: typeof AddArgKind.AUTH; strategies: AuthStrategyType[] }
-  | { kind: typeof AddArgKind.FEATURE; feature: ExtraFeature };
+  | {
+      kind: typeof AddArgKind.AUTH;
+      strategies: AuthStrategyType[];
+      apiKeyInternalSubnet?: boolean;
+    }
+  | { kind: typeof AddArgKind.FEATURE; feature: ExtraFeature }
+  | {
+      kind: typeof AddArgKind.AI_CONTEXT;
+      targets: AiContextTargetType[];
+    };
 
 export function parseAddArgs(args: string[]): AddArg[] {
   const parsed: AddArg[] = [];
@@ -165,13 +214,55 @@ export function parseAddArgs(args: string[]): AddArg[] {
 
       if (strategies.length === 0) {
         throw new Error(
-          'Use: kl-nest add auth jwt  ou  kl-nest add auth oauth2  ou  kl-nest add auth jwt oauth2',
+          'Use: kl-nest add auth jwt  ou  kl-nest add auth oauth2  ou  kl-nest add auth jwt api-key',
         );
+      }
+
+      let apiKeyInternalSubnet = false;
+
+      if (args[cursor]?.toLowerCase() === '--api-key-internal-subnet') {
+        apiKeyInternalSubnet = true;
+        cursor += 1;
       }
 
       parsed.push({
         kind: AddArgKind.AUTH,
         strategies: Array.from(new Set(strategies)),
+        apiKeyInternalSubnet,
+      });
+      index = cursor - 1;
+      continue;
+    }
+
+    if (arg === AddArgKind.AI_CONTEXT) {
+      const targets: AiContextTargetType[] = [];
+      let cursor = index + 1;
+
+      while (cursor < args.length) {
+        const token = args[cursor]?.toLowerCase();
+
+        if (!token) {
+          break;
+        }
+
+        try {
+          targets.push(parseAiContextTarget(token));
+        } catch {
+          break;
+        }
+
+        cursor += 1;
+      }
+
+      if (targets.length === 0) {
+        throw new Error(
+          'Use: kl-nest add ai-context cursor  ou  kl-nest add ai-context github  ou  kl-nest add ai-context cursor github',
+        );
+      }
+
+      parsed.push({
+        kind: AddArgKind.AI_CONTEXT,
+        targets: Array.from(new Set(targets)),
       });
       index = cursor - 1;
       continue;
@@ -181,7 +272,7 @@ export function parseAddArgs(args: string[]): AddArg[] {
 
     if (!feature) {
       throw new Error(
-        `Opção desconhecida: "${args[index]}". Use: cache, auth, health, cron, events.`,
+        `Opção desconhecida: "${args[index]}". Use: cache, auth, health, cron, events, ai-context.`,
       );
     }
 
@@ -194,6 +285,8 @@ export function parseAddArgs(args: string[]): AddArg[] {
 export function dedupeAddArgs(args: AddArg[]): AddArg[] {
   const seenFeatures = new Set<ExtraFeature>();
   const authStrategies = new Set<AuthStrategyType>();
+  const aiContextTargets = new Set<AiContextTargetType>();
+  let apiKeyInternalSubnet = false;
   const result: AddArg[] = [];
 
   for (const arg of args) {
@@ -201,6 +294,19 @@ export function dedupeAddArgs(args: AddArg[]): AddArg[] {
       for (const strategy of arg.strategies) {
         authStrategies.add(strategy);
       }
+
+      if (arg.apiKeyInternalSubnet) {
+        apiKeyInternalSubnet = true;
+      }
+
+      continue;
+    }
+
+    if (arg.kind === AddArgKind.AI_CONTEXT) {
+      for (const target of arg.targets) {
+        aiContextTargets.add(target);
+      }
+
       continue;
     }
 
@@ -214,6 +320,14 @@ export function dedupeAddArgs(args: AddArg[]): AddArg[] {
     result.unshift({
       kind: AddArgKind.AUTH,
       strategies: Array.from(authStrategies),
+      apiKeyInternalSubnet,
+    });
+  }
+
+  if (aiContextTargets.size > 0) {
+    result.push({
+      kind: AddArgKind.AI_CONTEXT,
+      targets: Array.from(aiContextTargets),
     });
   }
 

--- a/libs/cli/utils/generate-jwt-keys.ts
+++ b/libs/cli/utils/generate-jwt-keys.ts
@@ -1,0 +1,20 @@
+import { generateKeyPairSync } from 'node:crypto';
+
+export type JwtKeyPairBase64 = {
+  privateKey: string;
+  publicKey: string;
+};
+
+/** Gera par RS256 (PEM) e retorna cada chave em base64, como espera o SecurityModule. */
+export function generateJwtKeyPairBase64(): JwtKeyPairBase64 {
+  const pair = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  return {
+    privateKey: Buffer.from(pair.privateKey).toString('base64'),
+    publicKey: Buffer.from(pair.publicKey).toString('base64'),
+  };
+}

--- a/libs/cli/utils/get-ai-context-assets-path.ts
+++ b/libs/cli/utils/get-ai-context-assets-path.ts
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { getPackageRoot } from './get-package-root';
+
+/** Pasta com AGENTS.md, .cursor/rules e .github para projetos gerados. */
+export function getAiContextAssetsPath(): string {
+  const root = getPackageRoot(import.meta.url);
+  const publishedAssets = path.join(root, 'cli', 'assets', 'ai-context');
+
+  if (existsSync(publishedAssets)) {
+    return publishedAssets;
+  }
+
+  const monorepoAssets = path.join(root, 'libs', 'cli', 'assets', 'ai-context');
+
+  if (existsSync(monorepoAssets)) {
+    return monorepoAssets;
+  }
+
+  throw new Error(
+    'Assets de contexto AI não encontrados (cli/assets/ai-context).',
+  );
+}

--- a/libs/cli/utils/install-ai-context.ts
+++ b/libs/cli/utils/install-ai-context.ts
@@ -1,0 +1,122 @@
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import {
+  AI_CONTEXT_AGENTS_PATH,
+  AI_CONTEXT_CURSOR_RULE_PATHS,
+  AI_CONTEXT_GITHUB_PATH,
+  AI_CONTEXT_LABELS,
+  AiContextTarget,
+  type AiContextTarget as AiContextTargetType,
+} from '@cli/constants/ai-context';
+import { getAiContextAssetsPath } from './get-ai-context-assets-path';
+import { resolveProjectPath } from './resolve-project-path';
+
+export type InstallAiContextResult = {
+  label: string;
+  installed: boolean;
+  reason?: string;
+};
+
+function copyIfMissing(
+  sourcePath: string,
+  targetPath: string,
+  force = false,
+): boolean {
+  if (!force && existsSync(targetPath)) {
+    return false;
+  }
+
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  cpSync(sourcePath, targetPath, { force: true });
+  return true;
+}
+
+function installAgentsFile(projectRoot: string, assetsRoot: string): boolean {
+  return copyIfMissing(
+    path.join(assetsRoot, AI_CONTEXT_AGENTS_PATH),
+    path.join(projectRoot, AI_CONTEXT_AGENTS_PATH),
+  );
+}
+
+function installCursorRules(
+  projectRoot: string,
+  assetsRoot: string,
+): { installed: boolean; skipped: boolean } {
+  let copied = 0;
+  let skipped = 0;
+
+  for (const relativePath of AI_CONTEXT_CURSOR_RULE_PATHS) {
+    const didCopy = copyIfMissing(
+      path.join(assetsRoot, relativePath),
+      path.join(projectRoot, relativePath),
+    );
+
+    if (didCopy) {
+      copied += 1;
+    } else {
+      skipped += 1;
+    }
+  }
+
+  return {
+    installed: copied > 0,
+    skipped: skipped === AI_CONTEXT_CURSOR_RULE_PATHS.length,
+  };
+}
+
+function installGithubInstructions(
+  projectRoot: string,
+  assetsRoot: string,
+): boolean {
+  return copyIfMissing(
+    path.join(assetsRoot, AI_CONTEXT_GITHUB_PATH),
+    path.join(projectRoot, AI_CONTEXT_GITHUB_PATH),
+  );
+}
+
+/**
+ * Copia contexto AI para o projeto.
+ * Não sobrescreve arquivos já existentes (idempotente / preserva customizações).
+ */
+export function installAiContext(
+  projectName: string,
+  targets: readonly AiContextTargetType[],
+): InstallAiContextResult[] {
+  if (targets.length === 0) {
+    return [];
+  }
+
+  const projectRoot = resolveProjectPath(projectName);
+  const assetsRoot = getAiContextAssetsPath();
+  const uniqueTargets = Array.from(new Set(targets));
+  const results: InstallAiContextResult[] = [];
+
+  installAgentsFile(projectRoot, assetsRoot);
+
+  for (const target of uniqueTargets) {
+    if (target === AiContextTarget.CURSOR) {
+      const cursorResult = installCursorRules(projectRoot, assetsRoot);
+
+      results.push({
+        label: AI_CONTEXT_LABELS[AiContextTarget.CURSOR],
+        installed: cursorResult.installed,
+        reason: cursorResult.skipped
+          ? 'Regras Cursor já estão instaladas.'
+          : undefined,
+      });
+      continue;
+    }
+
+    const installed = installGithubInstructions(projectRoot, assetsRoot);
+
+    results.push({
+      label: AI_CONTEXT_LABELS[AiContextTarget.GITHUB],
+      installed,
+      reason: installed
+        ? undefined
+        : 'Instruções do GitHub Copilot já estão instaladas.',
+    });
+  }
+
+  return results;
+}

--- a/libs/cli/utils/install-module.ts
+++ b/libs/cli/utils/install-module.ts
@@ -56,6 +56,7 @@ export {
 
 export type InstallModuleOptions = {
   authStrategies?: AuthStrategy[];
+  apiKeyInternalSubnet?: boolean;
   withRedis?: boolean;
   withRedisIndicator?: boolean;
   skipPackages?: boolean;
@@ -406,6 +407,7 @@ export async function installModule(
         options.authStrategies?.length
           ? options.authStrategies
           : [AuthStrategy.JWT],
+        { apiKeyInternalSubnet: options.apiKeyInternalSubnet },
       );
       break;
     }

--- a/libs/cli/utils/install-workspace-config.ts
+++ b/libs/cli/utils/install-workspace-config.ts
@@ -1,7 +1,10 @@
 import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import type { PackageManager } from '@cli/types';
+import type { AiContextTarget } from '@cli/constants/ai-context';
 import { getSourceCodePath } from './get-source-code-path';
+import { installAiContext } from './install-ai-context';
+import { ensureJwtKeysInEnv } from './patch-env';
 import { resolveProjectPath } from './resolve-project-path';
 
 const PACKAGE_MANAGER_COMMAND: Record<PackageManager, string> = {
@@ -133,12 +136,18 @@ export function createEnvFromExample(projectName: string): void {
 
   writeFileSync(examplePath, envContent);
   writeFileSync(envPath, envContent);
+  ensureJwtKeysInEnv(projectName);
 }
 
 export function finalizeNewProjectSetup(
   projectName: string,
   packageManager: PackageManager,
+  aiContext: readonly AiContextTarget[] = [],
 ): void {
   installWorkspaceConfig(projectName, packageManager);
   createEnvFromExample(projectName);
+
+  if (aiContext.length > 0) {
+    installAiContext(projectName, aiContext);
+  }
 }

--- a/libs/cli/utils/normalize-add-args.ts
+++ b/libs/cli/utils/normalize-add-args.ts
@@ -11,6 +11,10 @@ export function normalizeAddArgs(args: AddArg[]): AddArg[] {
     (item): item is Extract<AddArg, { kind: typeof AddArgKind.AUTH }> =>
       item.kind === AddArgKind.AUTH,
   );
+  const aiContext = args.find(
+    (item): item is Extract<AddArg, { kind: typeof AddArgKind.AI_CONTEXT }> =>
+      item.kind === AddArgKind.AI_CONTEXT,
+  );
   const selectedFeatures = new Set(
     args
       .filter(
@@ -40,6 +44,10 @@ export function normalizeAddArgs(args: AddArg[]): AddArg[] {
     } else {
       ordered.unshift(authArg);
     }
+  }
+
+  if (aiContext) {
+    ordered.push(aiContext);
   }
 
   return ordered;

--- a/libs/cli/utils/parse-new-args.ts
+++ b/libs/cli/utils/parse-new-args.ts
@@ -7,6 +7,7 @@ import {
   Template,
   TEMPLATE_ALIASES,
 } from '@cli/constants/domain';
+import type { AiContextTarget } from '@cli/constants/ai-context';
 
 export type ParsedNewArgs = {
   projectName?: string;
@@ -14,6 +15,8 @@ export type ParsedNewArgs = {
   template?: Template;
   auth?: AuthStrategy[];
   features: ExtraFeature[];
+  aiContext: AiContextTarget[];
+  apiKeyInternalSubnet: boolean;
   yes: boolean;
   interactive: boolean;
 };
@@ -65,6 +68,7 @@ export function parseNewArgs(args: string[]): ParsedNewArgs {
   let auth: ParsedNewArgs['auth'];
   let features: ExtraFeature[] = [];
   let yes = false;
+  let apiKeyInternalSubnet = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -75,6 +79,11 @@ export function parseNewArgs(args: string[]): ParsedNewArgs {
 
     if (arg === '-y' || arg === '--yes') {
       yes = true;
+      continue;
+    }
+
+    if (arg === '--api-key-internal-subnet') {
+      apiKeyInternalSubnet = true;
       continue;
     }
 
@@ -151,6 +160,8 @@ export function parseNewArgs(args: string[]): ParsedNewArgs {
     template,
     auth,
     features,
+    aiContext: [],
+    apiKeyInternalSubnet,
     yes,
     interactive: !yes,
   };
@@ -190,6 +201,8 @@ export function buildNewProjectConfig(
     template: Template;
     auth: AuthStrategy[];
     features: ExtraFeature[];
+    apiKeyInternalSubnet?: boolean;
+    aiContext?: AiContextTarget[];
   },
 ) {
   return {
@@ -198,5 +211,8 @@ export function buildNewProjectConfig(
     template: parsed.template ?? overrides.template,
     auth: parsed.auth ?? overrides.auth,
     features: parsed.features.length > 0 ? parsed.features : overrides.features,
+    apiKeyInternalSubnet:
+      overrides.apiKeyInternalSubnet ?? parsed.apiKeyInternalSubnet,
+    aiContext: overrides.aiContext ?? parsed.aiContext,
   };
 }

--- a/libs/cli/utils/patch-auth-install.ts
+++ b/libs/cli/utils/patch-auth-install.ts
@@ -11,9 +11,14 @@ import { syncAuthStrategySupportFiles } from './sync-auth-strategy-files';
 import {
   installAuthArtifactsForStrategies,
   pruneAuthArtifactsForStrategies,
+  syncApiKeyArtifactsForStrategies,
 } from './prune-auth-strategies';
 
 export type { AuthStrategy } from '@cli/constants/domain';
+
+export type PatchAuthInstallOptions = {
+  apiKeyInternalSubnet?: boolean;
+};
 
 function patchFile(
   projectName: string,
@@ -288,6 +293,7 @@ export function syncSecurityModuleForProject(
 export async function patchAuthInstall(
   projectName: string,
   strategies: AuthStrategy[],
+  options: PatchAuthInstallOptions = {},
 ) {
   if (strategies.length === 0) {
     throw new Error('Informe ao menos uma estratégia de autenticação.');
@@ -334,5 +340,8 @@ export async function patchAuthInstall(
   syncDefineDocumentationForProject(projectName, strategies);
   syncAuthStrategySupportFiles(projectName, strategies);
   pruneAuthArtifactsForStrategies(projectName, strategies);
+  syncApiKeyArtifactsForStrategies(projectName, strategies, {
+    apiKeyInternalSubnet: options.apiKeyInternalSubnet,
+  });
   patchEnvForAuthStrategies(projectName, strategies);
 }

--- a/libs/cli/utils/patch-define-documentation.ts
+++ b/libs/cli/utils/patch-define-documentation.ts
@@ -231,6 +231,7 @@ export function syncDefineDocumentationForProject(
 ) {
   const hasJwt = strategies.includes(AuthStrategy.JWT);
   const hasOauth = strategies.includes(AuthStrategy.OAUTH2);
+  const hasApiKey = strategies.includes(AuthStrategy.API_KEY);
   const targetPath = path.join(
     resolveProjectPath(projectName),
     'src/host/open-api/define-documentation.ts',
@@ -238,7 +239,7 @@ export function syncDefineDocumentationForProject(
 
   mkdirSync(path.dirname(targetPath), { recursive: true });
 
-  if (hasJwt && !hasOauth) {
+  if (hasJwt && !hasOauth && !hasApiKey) {
     writeFileSync(targetPath, defineDocumentationJwtOnly);
     return;
   }

--- a/libs/cli/utils/patch-env.ts
+++ b/libs/cli/utils/patch-env.ts
@@ -1,8 +1,118 @@
-import { cpSync, mkdirSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { AuthStrategy } from '@cli/constants/domain';
+import { generateJwtKeyPairBase64 } from './generate-jwt-keys';
 import { getSourceCodePath } from './get-source-code-path';
 import { resolveProjectPath } from './resolve-project-path';
+
+const JWT_PRIVATE_KEY = 'JWT_PRIVATE_KEY';
+const JWT_PUBLIC_KEY = 'JWT_PUBLIC_KEY';
+
+function readEnvAssignment(
+  content: string,
+  key: string,
+): { exists: boolean; value: string } {
+  const match = content.match(new RegExp(`^${key}=(.*)$`, 'm'));
+
+  if (!match) {
+    return { exists: false, value: '' };
+  }
+
+  return { exists: true, value: match[1] ?? '' };
+}
+
+function writeJwtKeysInEnvContent(
+  content: string,
+  privateKey: string,
+  publicKey: string,
+): string {
+  let next = content;
+  const hasPrivate = new RegExp(`^${JWT_PRIVATE_KEY}=`, 'm').test(next);
+  const hasPublic = new RegExp(`^${JWT_PUBLIC_KEY}=`, 'm').test(next);
+
+  if (hasPrivate) {
+    next = next.replace(
+      new RegExp(`^${JWT_PRIVATE_KEY}=.*$`, 'm'),
+      `${JWT_PRIVATE_KEY}=${privateKey}`,
+    );
+  }
+
+  if (hasPublic) {
+    next = next.replace(
+      new RegExp(`^${JWT_PUBLIC_KEY}=.*$`, 'm'),
+      `${JWT_PUBLIC_KEY}=${publicKey}`,
+    );
+  }
+
+  if (hasPrivate && hasPublic) {
+    return next;
+  }
+
+  if (!hasPrivate && !hasPublic) {
+    return `${next.trimEnd()}\n\n# JWT (RS256 — chaves em base64)\n${JWT_PRIVATE_KEY}=${privateKey}\n${JWT_PUBLIC_KEY}=${publicKey}\n`;
+  }
+
+  if (!hasPrivate) {
+    return next.replace(
+      new RegExp(`^${JWT_PUBLIC_KEY}=`, 'm'),
+      `${JWT_PRIVATE_KEY}=${privateKey}\n${JWT_PUBLIC_KEY}=`,
+    );
+  }
+
+  return next.replace(
+    new RegExp(`^${JWT_PRIVATE_KEY}=.*$`, 'm'),
+    `${JWT_PRIVATE_KEY}=${privateKey}\n${JWT_PUBLIC_KEY}=${publicKey}`,
+  );
+}
+
+/**
+ * Preenche JWT_PRIVATE_KEY / JWT_PUBLIC_KEY no `.env` com um par RS256 gerado.
+ * Não sobrescreve quando ambas já têm valor. `.env.example` permanece vazio (template).
+ */
+export function ensureJwtKeysInEnv(
+  projectName: string,
+  options: { addIfMissing?: boolean } = {},
+): boolean {
+  const envPath = path.join(resolveProjectPath(projectName), '.env');
+
+  if (!existsSync(envPath)) {
+    return false;
+  }
+
+  const content = readFileSync(envPath, 'utf8');
+  const privateKey = readEnvAssignment(content, JWT_PRIVATE_KEY);
+  const publicKey = readEnvAssignment(content, JWT_PUBLIC_KEY);
+
+  if (!privateKey.exists && !publicKey.exists && !options.addIfMissing) {
+    return false;
+  }
+
+  if (privateKey.value.trim() && publicKey.value.trim()) {
+    return false;
+  }
+
+  const keys = generateJwtKeyPairBase64();
+  writeFileSync(
+    envPath,
+    writeJwtKeysInEnvContent(content, keys.privateKey, keys.publicKey),
+  );
+
+  return true;
+}
+
+function authNeedsJwtKeys(strategies: AuthStrategy[]): boolean {
+  return (
+    strategies.includes(AuthStrategy.JWT) ||
+    strategies.includes(AuthStrategy.OAUTH2) ||
+    strategies.includes(AuthStrategy.API_KEY)
+  );
+}
 
 const envWithoutAuth = `import { envBooleanSchema } from '@/core/schemas';
 import { z } from 'zod';
@@ -157,8 +267,11 @@ export function patchEnvForAuthStrategies(
       path.join(projectRoot, '.env.example'),
       envExampleJwtOnly,
     );
-    return;
+  } else {
+    restoreEnvWithAuth(projectName);
   }
 
-  restoreEnvWithAuth(projectName);
+  if (authNeedsJwtKeys(strategies)) {
+    ensureJwtKeysInEnv(projectName, { addIfMissing: true });
+  }
 }

--- a/libs/cli/utils/prune-auth-strategies.ts
+++ b/libs/cli/utils/prune-auth-strategies.ts
@@ -1,6 +1,15 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import {
+  API_KEY_INSTALL_PATHS,
+  API_KEY_SUBNET_PATH,
   JWT_ONLY_REMOVE_PATHS,
   OAUTH2_INSTALL_PATHS,
   OAUTH2_ONLY_REMOVE_PATHS,
@@ -9,6 +18,7 @@ import { AuthStrategy } from '@cli/constants/domain';
 import { getSourceCodePath } from './get-source-code-path';
 import { resolveProjectPath } from './resolve-project-path';
 import { assertAuthStrategyProject } from './auth-strategy-validation';
+import { removeImportLines } from './project-files';
 
 function projectPath(projectName: string, relativePath: string) {
   return path.join(resolveProjectPath(projectName), relativePath);
@@ -37,6 +47,340 @@ function installPath(projectName: string, relativePath: string) {
 
   mkdirSync(path.dirname(to), { recursive: true });
   cpSync(from, to, { recursive: true, force: true });
+}
+
+function readProject(projectName: string, relativePath: string) {
+  return readFileSync(projectPath(projectName, relativePath), 'utf8');
+}
+
+function writeProject(projectName: string, relativePath: string, content: string) {
+  const target = projectPath(projectName, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+const AUTHORIZATION_WITHOUT_SUBNET = `import { EnvConfig } from '@/core/utils/env.config';
+import {
+  matchApiKeyDomainOrigin,
+  resolveClientIp,
+} from '@/core/utils/match-api-key-domain-origin';
+import { ApiKeyType } from '@/domain/entities/api-key/enums/api-key-type.enum';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+@Injectable()
+export class ApiKeyAuthorizationService {
+  constructor(private readonly apiKeyRepository: IApiKeyRepository) {}
+
+  private async validateDomainOrigin(
+    origins: string[],
+    req: Request,
+  ): Promise<boolean> {
+    const clientIp = resolveClientIp(req);
+
+    if (!clientIp) {
+      return false;
+    }
+
+    return matchApiKeyDomainOrigin(clientIp, origins);
+  }
+
+  async validateApiKey(
+    userId: string,
+    apiKeyId: string,
+    req: Request,
+  ): Promise<boolean> {
+    const apiKey = await this.apiKeyRepository.findById(apiKeyId);
+
+    if (!apiKey || apiKey.userId !== userId) {
+      return false;
+    }
+
+    const origins = apiKey.origin.split(',').map((origin) => origin.trim());
+
+    if (
+      (EnvConfig.isEnvTest || EnvConfig.isEnvDevelop) &&
+      origins.includes('*')
+    ) {
+      return true;
+    }
+
+    switch (apiKey.type) {
+      case ApiKeyType.domain:
+        return this.validateDomainOrigin(origins, req);
+      case ApiKeyType.host:
+        return origins.includes(req.hostname);
+      case ApiKeyType.uri: {
+        let uri = \`\${req.hostname}\${req.path}\`;
+
+        for (const param of Object.values(req.params)) {
+          if (typeof param === 'string' && param.length > 0) {
+            uri = uri.replace(\`/\${param}\`, '');
+          }
+        }
+
+        return origins.includes(uri);
+      }
+      default:
+        return false;
+    }
+  }
+}
+`;
+
+export function stripApiKeyFromAppModule(content: string) {
+  let patched = removeImportLines(content, [
+    './controllers/api-key/api-key.module',
+  ]);
+  patched = patched.replace(/\s*ApiKeyModule,\n/g, '\n');
+  return patched;
+}
+
+export function stripApiKeyFromRepositoryModule(content: string) {
+  let patched = removeImportLines(content, [
+    '@/domain/repositories/iapi-key.repository',
+    '@/infra/repositories/api-key.repository',
+  ]);
+  patched = patched.replace(
+    /\s*\{ provide: IApiKeyRepository, useClass: ApiKeyRepository \},?\n/g,
+    '\n',
+  );
+  patched = patched.replace(/\n\s*IApiKeyRepository,?/g, '');
+  patched = patched.replace(/, IApiKeyRepository/g, '');
+  patched = patched.replace(/IApiKeyRepository, /g, '');
+  return patched;
+}
+
+export function stripApiKeyFromSecurityModule(content: string) {
+  let patched = removeImportLines(content, [
+    '@/infra/auth/api-key-authorization.service',
+    './strategies/api-key.strategy',
+  ]);
+  patched = patched.replace(/\s*ApiKeyStrategy,\n/g, '\n');
+  patched = patched.replace(/\s*ApiKeyAuthorizationService,\n/g, '\n');
+  return patched;
+}
+
+export function stripApiKeyFromAuthGuard(content: string) {
+  return content.replace(
+    "NestAuthGuard(['jwt', 'apikey'])",
+    "NestAuthGuard('jwt')",
+  );
+}
+
+export function stripApiKeyFromMappingProvider(content: string) {
+  let patched = removeImportLines(content, ['./api-key.mapper']);
+  patched = patched.replace(/\s*ApiKeyMapper\.createMap\(\);\n/g, '\n');
+  return patched;
+}
+
+export function syncApiKeyArtifactsForStrategies(
+  projectName: string,
+  strategies: readonly AuthStrategy[],
+  options: { apiKeyInternalSubnet?: boolean } = {},
+) {
+  const hasApiKey = strategies.includes(AuthStrategy.API_KEY);
+  const wantSubnet = options.apiKeyInternalSubnet === true;
+
+  if (hasApiKey) {
+    for (const relativePath of API_KEY_INSTALL_PATHS) {
+      installPath(projectName, relativePath);
+    }
+
+    const mappingPath = 'src/application/mapping/mapping.provider.ts';
+    if (existsSync(projectPath(projectName, mappingPath))) {
+      let mapping = readProject(projectName, mappingPath);
+
+      if (!mapping.includes('ApiKeyMapper')) {
+        if (!mapping.includes("./api-key.mapper")) {
+          mapping = mapping.replace(
+            "import { PersonMapper } from './person.mapper';",
+            "import { ApiKeyMapper } from './api-key.mapper';\nimport { PersonMapper } from './person.mapper';",
+          );
+
+          if (!mapping.includes("./api-key.mapper")) {
+            mapping = mapping.replace(
+              "import { Injectable } from '@nestjs/common';",
+              "import { Injectable } from '@nestjs/common';\nimport { ApiKeyMapper } from './api-key.mapper';",
+            );
+          }
+        }
+
+        if (!mapping.includes('ApiKeyMapper.createMap()')) {
+          mapping = mapping.replace(
+            'PersonMapper.createMap();',
+            'PersonMapper.createMap();\n    ApiKeyMapper.createMap();',
+          );
+
+          if (!mapping.includes('ApiKeyMapper.createMap()')) {
+            mapping = mapping.replace(
+              'constructor() {',
+              'constructor() {\n    ApiKeyMapper.createMap();',
+            );
+          }
+        }
+
+        writeProject(projectName, mappingPath, mapping);
+      }
+    }
+
+    if (wantSubnet) {
+      installPath(projectName, API_KEY_SUBNET_PATH);
+      installPath(
+        projectName,
+        'src/infra/auth/api-key-authorization.service.ts',
+      );
+    } else {
+      removePaths(projectName, [API_KEY_SUBNET_PATH]);
+      writeProject(
+        projectName,
+        'src/infra/auth/api-key-authorization.service.ts',
+        AUTHORIZATION_WITHOUT_SUBNET,
+      );
+    }
+
+    const repositoryPath = 'src/infra/repositories/repository.module.ts';
+    if (existsSync(projectPath(projectName, repositoryPath))) {
+      let repository = readProject(projectName, repositoryPath);
+
+      if (!repository.includes('IApiKeyRepository')) {
+        repository = repository.replace(
+          "import { IUserRepository } from '@/domain/repositories/iuser.repository';",
+          "import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';\nimport { IUserRepository } from '@/domain/repositories/iuser.repository';",
+        );
+        repository = repository.replace(
+          "import { UserRepository } from '@/infra/repositories/user.repository';",
+          "import { ApiKeyRepository } from '@/infra/repositories/api-key.repository';\nimport { UserRepository } from '@/infra/repositories/user.repository';",
+        );
+        repository = repository.replace(
+          '{ provide: IUserRepository, useClass: UserRepository },',
+          '{ provide: IUserRepository, useClass: UserRepository },\n    { provide: IApiKeyRepository, useClass: ApiKeyRepository },',
+        );
+        repository = repository.replace(
+          'exports: [DatabaseModule, IPersonRepository, IUserRepository]',
+          'exports: [DatabaseModule, IPersonRepository, IUserRepository, IApiKeyRepository]',
+        );
+        repository = repository.replace(
+          'exports: [DatabaseModule, IUserRepository]',
+          'exports: [DatabaseModule, IUserRepository, IApiKeyRepository]',
+        );
+
+        if (
+          repository.includes('IUserRepository') &&
+          !repository.includes('IApiKeyRepository')
+        ) {
+          repository = repository.replace(
+            'exports: [DatabaseModule, IUserRepository]',
+            'exports: [DatabaseModule, IUserRepository, IApiKeyRepository]',
+          );
+        }
+
+        writeProject(projectName, repositoryPath, repository);
+      }
+    }
+
+    const appModulePath = 'src/host/app.module.ts';
+    if (existsSync(projectPath(projectName, appModulePath))) {
+      let appModule = readProject(projectName, appModulePath);
+
+      if (!appModule.includes('ApiKeyModule')) {
+        appModule = appModule.replace(
+          "import { AuthModule } from './controllers/auth/auth.module';",
+          "import { ApiKeyModule } from './controllers/api-key/api-key.module';\nimport { AuthModule } from './controllers/auth/auth.module';",
+        );
+        appModule = appModule.replace(
+          'AuthModule,\n',
+          'AuthModule,\n    ApiKeyModule,\n',
+        );
+        writeProject(projectName, appModulePath, appModule);
+      }
+    }
+
+    const securityPath = 'src/host/security/security.module.ts';
+    if (existsSync(projectPath(projectName, securityPath))) {
+      let security = readProject(projectName, securityPath);
+
+      if (!security.includes('ApiKeyStrategy')) {
+        installPath(projectName, 'src/host/security/strategies/api-key.strategy.ts');
+        security = readProject(projectName, securityPath);
+
+        if (!security.includes('ApiKeyStrategy')) {
+          security = security.replace(
+            "import { JwtStrategy } from './strategies/jwt.strategy';",
+            "import { ApiKeyAuthorizationService } from '@/infra/auth/api-key-authorization.service';\nimport { ApiKeyStrategy } from './strategies/api-key.strategy';\nimport { JwtStrategy } from './strategies/jwt.strategy';",
+          );
+          security = security.replace(
+            'JwtStrategy,\n',
+            'JwtStrategy,\n    ApiKeyStrategy,\n    ApiKeyAuthorizationService,\n',
+          );
+          writeProject(projectName, securityPath, security);
+        }
+      }
+    }
+
+    const guardPath = 'src/host/security/guards/auth.guard.ts';
+    if (existsSync(projectPath(projectName, guardPath))) {
+      const guard = readProject(projectName, guardPath);
+
+      if (!guard.includes("'apikey'")) {
+        writeProject(
+          projectName,
+          guardPath,
+          guard.replace("NestAuthGuard('jwt')", "NestAuthGuard(['jwt', 'apikey'])"),
+        );
+      }
+    }
+
+    return;
+  }
+
+  removePaths(projectName, [...API_KEY_INSTALL_PATHS, API_KEY_SUBNET_PATH]);
+
+  const appModulePath = 'src/host/app.module.ts';
+  if (existsSync(projectPath(projectName, appModulePath))) {
+    writeProject(
+      projectName,
+      appModulePath,
+      stripApiKeyFromAppModule(readProject(projectName, appModulePath)),
+    );
+  }
+
+  const repositoryPath = 'src/infra/repositories/repository.module.ts';
+  if (existsSync(projectPath(projectName, repositoryPath))) {
+    writeProject(
+      projectName,
+      repositoryPath,
+      stripApiKeyFromRepositoryModule(readProject(projectName, repositoryPath)),
+    );
+  }
+
+  const securityPath = 'src/host/security/security.module.ts';
+  if (existsSync(projectPath(projectName, securityPath))) {
+    writeProject(
+      projectName,
+      securityPath,
+      stripApiKeyFromSecurityModule(readProject(projectName, securityPath)),
+    );
+  }
+
+  const guardPath = 'src/host/security/guards/auth.guard.ts';
+  if (existsSync(projectPath(projectName, guardPath))) {
+    writeProject(
+      projectName,
+      guardPath,
+      stripApiKeyFromAuthGuard(readProject(projectName, guardPath)),
+    );
+  }
+
+  const mappingPath = 'src/application/mapping/mapping.provider.ts';
+  if (existsSync(projectPath(projectName, mappingPath))) {
+    writeProject(
+      projectName,
+      mappingPath,
+      stripApiKeyFromMappingProvider(readProject(projectName, mappingPath)),
+    );
+  }
 }
 
 export function installAuthArtifactsForStrategies(
@@ -75,7 +419,10 @@ export function pruneAuthArtifactsForStrategies(
   }
 }
 
-export { assertAuthStrategyProject, listAuthStrategyViolations } from './auth-strategy-validation';
+export {
+  assertAuthStrategyProject,
+  listAuthStrategyViolations,
+} from './auth-strategy-validation';
 
 export function assertAuthStrategyPaths(
   projectName: string,
@@ -83,6 +430,7 @@ export function assertAuthStrategyPaths(
 ) {
   const hasJwt = strategies.includes(AuthStrategy.JWT);
   const hasOauth = strategies.includes(AuthStrategy.OAUTH2);
+  const hasApiKey = strategies.includes(AuthStrategy.API_KEY);
   const root = resolveProjectPath(projectName);
 
   const expectations = [
@@ -117,6 +465,14 @@ export function assertAuthStrategyPaths(
     {
       path: 'src/core/auth/oauth-provider.registry.ts',
       shouldExist: hasOauth,
+    },
+    {
+      path: 'src/host/controllers/api-key/api-key.module.ts',
+      shouldExist: hasApiKey,
+    },
+    {
+      path: 'src/host/security/strategies/api-key.strategy.ts',
+      shouldExist: hasApiKey,
     },
   ];
 

--- a/libs/cli/utils/remove-sample-parts.ts
+++ b/libs/cli/utils/remove-sample-parts.ts
@@ -47,6 +47,14 @@ const partsToRemove: PartsToRemove[] = [
         from: 'providers: [{ provide: IUserRepository, useClass: UserRepository }],\n',
         to: '',
       },
+      {
+        from: 'exports: [\n    DatabaseModule,\n    IPersonRepository,\n    IUserRepository,\n    IApiKeyRepository,\n  ],',
+        to: 'exports: [DatabaseModule],',
+      },
+      {
+        from: 'exports: [\n    DatabaseModule,\n    IPersonRepository,\n    IUserRepository,\n  ],',
+        to: 'exports: [DatabaseModule],',
+      },
       { from: ', IPersonRepository', to: '' },
       { from: ', IUserRepository', to: '' },
       { from: ', IApiKeyRepository', to: '' },

--- a/libs/cli/utils/remove-sample-parts.ts
+++ b/libs/cli/utils/remove-sample-parts.ts
@@ -27,8 +27,14 @@ const partsToRemove: PartsToRemove[] = [
       './person.repository',
       '@/domain/repositories/iuser.repository',
       '@/infra/repositories/user.repository',
+      '@/domain/repositories/iapi-key.repository',
+      '@/infra/repositories/api-key.repository',
     ],
     replace: [
+      {
+        from: 'providers: [\n    { provide: IPersonRepository, useClass: PersonRepository },\n    { provide: IUserRepository, useClass: UserRepository },\n    { provide: IApiKeyRepository, useClass: ApiKeyRepository },\n  ],\n',
+        to: '',
+      },
       {
         from: 'providers: [\n    { provide: IPersonRepository, useClass: PersonRepository },\n    { provide: IUserRepository, useClass: UserRepository },\n  ],\n',
         to: '',
@@ -43,25 +49,32 @@ const partsToRemove: PartsToRemove[] = [
       },
       { from: ', IPersonRepository', to: '' },
       { from: ', IUserRepository', to: '' },
+      { from: ', IApiKeyRepository', to: '' },
+      { from: 'IApiKeyRepository,\n', to: '' },
     ],
   },
   {
     path: 'src/host/app.module.ts',
     removeImports: [
       './controllers/person/person.module',
+      './controllers/api-key/api-key.module',
       '@/application/person/jobs/events/person/inactive-person/inactive-person.handler',
       '@/application/person/jobs/cron/create-person.job',
       '@/application/person/jobs/cron/delete-inactive.job',
     ],
     replace: [
       { from: 'PersonModule,\n', to: '' },
+      { from: 'ApiKeyModule,\n', to: '' },
       { from: 'imports: [PersonModule],\n      ', to: '' },
     ],
   },
   {
     path: 'src/application/mapping/mapping.provider.ts',
-    removeImports: ['./person.mapper'],
-    replace: [{ from: 'PersonMapper.createMap();', to: '' }],
+    removeImports: ['./person.mapper', './api-key.mapper'],
+    replace: [
+      { from: 'PersonMapper.createMap();', to: '' },
+      { from: 'ApiKeyMapper.createMap();', to: '' },
+    ],
   },
 ];
 
@@ -103,20 +116,30 @@ const defaultTemplatePathsToRemoveWithoutAuth = [
 
 const defaultTemplateAuthArtifactPaths = [
   'src/application/auth',
+  'src/application/api-key',
   'src/domain/auth',
   'src/domain/entities/user',
+  'src/domain/entities/api-key',
   'src/domain/repositories/iuser.repository.ts',
+  'src/domain/repositories/iapi-key.repository.ts',
   'src/domain/dtos/logged-user-info.dto.ts',
   'src/domain/services',
   'src/infra/auth',
   'src/infra/repositories/user.repository.ts',
+  'src/infra/repositories/api-key.repository.ts',
   'src/infra/services/logged-user-info.service.ts',
+  'src/infra/database/migrations/1781281330534-CreateApiKey.ts',
   'src/host/security',
   'src/host/controllers/auth',
   'src/host/controllers/oauth2',
+  'src/host/controllers/api-key',
+  'src/application/mapping/api-key.mapper.ts',
   'src/core/types/auth-provider-config-response.type.ts',
   'src/core/utils/hash-password.ts',
   'src/core/utils/name-to-login.ts',
+  'src/core/utils/capture-apikey-on-request.ts',
+  'src/core/utils/match-api-key-domain-origin.ts',
+  'src/core/utils/internal-subnet-validator.ts',
 ];
 
 function removePaths(projectName: string, paths: string[]) {

--- a/libs/doc/markdown/en/getting-started/environment-variables.md
+++ b/libs/doc/markdown/en/getting-started/environment-variables.md
@@ -44,7 +44,7 @@ export const envSchema = z.object({
 
 ## `.env` file
 
-Create a `.env` at the project root (the CLI also copies `.env.example` as a reference):
+The CLI creates `.env` from `.env.example` on `kl-nest new`. With auth (JWT / OAuth2 / API Key), JWT keys are already filled in `.env` (the example stays empty):
 
 ```env
 PORT=3000
@@ -77,6 +77,8 @@ Included in core via `applyHttpMiddleware`. Full guide: [HTTP middleware](../hos
 | `BCRYPT_ROUNDS` | Password hash cost (default `10`) |
 
 ### Authentication (when installed)
+
+With `kl-nest new --auth jwt` (or `api-key` / OAuth2) and `kl-nest add auth …`, the CLI generates an RS256 key pair and fills `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` in `.env` (base64). `.env.example` keeps empty placeholders. Existing non-empty values in `.env` are not overwritten.
 
 ```env
 JWT_PRIVATE_KEY=<RS256 private key in base64>

--- a/libs/doc/markdown/en/getting-started/installation-guide.md
+++ b/libs/doc/markdown/en/getting-started/installation-guide.md
@@ -47,8 +47,11 @@ The `new` command prompts for:
 - project name;
 - package manager (`bun`, `npm`, or `pnpm` — Bun recommended);
 - template (**Default** or **CRUD Example**);
-- authentication strategy (**JWT** or **OAuth2** — required on CRUD);
-- extra features (**Default**: cache, health, cron, events; **CRUD**: health check only — auth, Redis cache, and jobs are bundled).
+- authentication strategy (**JWT**, **OAuth2**, and/or **API Key** — required on CRUD; API Key is additive);
+- extra features (**Default**: cache, health, cron, events; **CRUD**: health check only — auth, Redis cache, and jobs are bundled);
+- **AI context** for vibecoding: **Cursor** (`.cursor/rules` + `AGENTS.md`), **GitHub Copilot** (`.github/copilot-instructions.md` + `AGENTS.md`), both, or none.
+
+With `-y` / `--yes`, AI context is **not** generated (same as empty features). You can add it later with `kl-nest add ai-context cursor` (and/or `github`).
 
 The **core** module installs only essentials (`@koalarx/utils`, `@nestjs/config`, `@nestjs/swagger`, `typeorm`, `pg`, `zod`, `@scalar/nestjs-api-reference`). Extra dependencies are added based on selected options:
 
@@ -84,6 +87,9 @@ kl-nest add
 kl-nest add cache
 kl-nest add auth jwt
 kl-nest add health cron events
+kl-nest add ai-context cursor
+kl-nest add ai-context github
+kl-nest add ai-context cursor github
 ```
 
 | Item | Command | Notes |
@@ -94,6 +100,8 @@ kl-nest add health cron events
 | Health check | `kl-nest add health` | Terminus: PostgreSQL ping + Redis (when configured) |
 | Cron jobs | `kl-nest add cron` | Requires in-memory cache (installed automatically) |
 | Event jobs | `kl-nest add events` | On CRUD, restores example handlers |
+| AI context (Cursor) | `kl-nest add ai-context cursor` | `AGENTS.md` + `.cursor/rules` (does not overwrite existing files) |
+| AI context (Copilot) | `kl-nest add ai-context github` | `AGENTS.md` + `.github/copilot-instructions.md` |
 
 ## Templates
 
@@ -103,7 +111,7 @@ kl-nest add health cron events
 
 ## Environment variables
 
-After creating the project, configure a `.env` at the root:
+After creating the project, the CLI already generates a `.env` from `.env.example` (with `DATABASE_URL` adjusted to the project name). With JWT / OAuth2 / API Key authentication, `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` are also generated automatically in `.env`.
 
 ```env
 PORT=3000

--- a/libs/doc/markdown/en/host/authentication.md
+++ b/libs/doc/markdown/en/host/authentication.md
@@ -4,12 +4,12 @@ slug: authentication
 category: host
 docKey: host/autenticacao
 order: 4
-description: JWT, global guards, public routes, and generic OAuth2.
+description: JWT, global guards, public routes, generic OAuth2, and API Key.
 ---
 
 # Authentication
 
-The authentication module is optional in the CLI (`kl-nest new` → **JWT** or **OAuth2**). With JWT, the template includes a `User` entity, email/password login, and RS256 token issuance. With OAuth2, users are created or reused after the authorization code flow.
+The authentication module is optional in the CLI (`kl-nest new` → **JWT**, **OAuth2**, and/or **API Key**). With JWT, the template includes a `User` entity, email/password login, and RS256 token issuance. With OAuth2, users are created or reused after the authorization code flow. **API Key** is additive (requires JWT and/or OAuth2) and authenticates machine-to-machine calls at the HTTP edge.
 
 Installing auth does **not** patch `data-source-factory.ts`: the `User` entity joins the DataSource via `@Entity` (DbContext), and `UserRepository` is registered in `RepositoryModule`.
 
@@ -18,7 +18,7 @@ Installing auth does **not** patch `data-source-factory.ts`: the `User` entity j
 | Piece | Role |
 | --- | --- |
 | `SecurityModule` | Configures RS256 JWT, Passport, and token/OAuth2 services |
-| `AuthGuard` | Global guard — validates Bearer token |
+| `AuthGuard` | Global guard — validates Bearer JWT and/or `ApiKey` header |
 | `ProfilesGuard` | Global guard — restricts by token profile |
 | `@IsPublic()` | Marks routes that bypass `AuthGuard` |
 | `@RestrictionByProfile([AuthProfile.admin])` | Restricts endpoint to listed profiles |
@@ -252,12 +252,37 @@ app.useGlobalGuards(
 
 Job bootstrap subscribes to domain events and starts CronJobs only when `CRON_JOBS_ENABLED=true`. The delay before starting jobs is controlled by `BOOTSTRAP_DELAY_MS`.
 
+## API Key (M2M)
+
+API Key authenticates synchronous HTTP callers (integrations, BFF, occasional service hops). It does **not** replace a message broker or force a file-proxy API — cloud storage + messaging remain the preferred scalable design. The strategy lives in the host layer; handlers only see the already-authenticated user via `ILoggedUserInfoService`.
+
+CLI: `--auth jwt,api-key` (or `oauth2,api-key` / `jwt,oauth2,api-key`). Optional `--api-key-internal-subnet` allows private (RFC1918) IPs for `domain` type when pods talk inside the cluster.
+
+### CRUD and token
+
+- Endpoints under `/api-key` (create/list/read/update/delete), scoped to the authenticated user
+- On create, the key is an RS256 JWT with `typ: api-key`, `sub` = userId, `iss` = key id — returned **only** in that response
+- Usage: header `ApiKey: <jwt>`
+
+### Origin types (`origin` CSV)
+
+| Type | Validation |
+| --- | --- |
+| `host` | `req.hostname` in the list |
+| `uri` | hostname + path (without route params) |
+| `domain` | Client IP vs registered IP **or** domain (reverse DNS / A/AAAA lookup). No `Origin`/`Referer` headers |
+
+`*` in the list only unlocks in `develop`/`test`. With internal subnet enabled, private IPs also pass `domain` without listing every pod.
+
+Enable `trust proxy` when the API sits behind a load balancer / ingress.
+
 ## Authentication in Scalar
 
-With authentication installed, Scalar obtains the JWT automatically via `authentication` in `apiReference`:
+With authentication installed, Scalar obtains credentials via `authentication` in `apiReference`:
 
 - **JWT:** **JWT** scheme (password flow) → `POST /auth/login`
 - **OAuth2:** one scheme per provider (authorization code) → `POST /oauth2/scalar-token`
+- **API Key:** **ApiKey** scheme (header `ApiKey`)
 
 Full guide: [OpenAPI with Scalar](./openapi-scalar.md#automatic-scalar-authentication)
 

--- a/libs/doc/markdown/en/intro/patch-notes.md
+++ b/libs/doc/markdown/en/intro/patch-notes.md
@@ -13,6 +13,24 @@ Changelog for anyone using or upgrading CLI-generated projects. Deep dives live 
 
 The published `@koalarx/nest` version is shown on the site and in the repo `package.json`. Root [`CHANGELOG.md`](https://github.com/igordrangel/koala-nest/blob/main/CHANGELOG.md) mirrors these notes.
 
+## 4.3.0 — API Key (M2M auth)
+
+### What changed
+
+- **New additive `api-key` strategy:** use with JWT and/or OAuth2 (`--auth jwt,api-key`). Cannot be selected alone.
+- **CRUD `/api-key`:** issues a long-lived RS256 JWT (`typ: api-key`) and validates origin (`domain` / `host` / `uri`).
+- **Optional internal subnet:** `--api-key-internal-subnet` (or CLI prompt) allows private IPs for pod-to-pod traffic on `domain` type.
+- **Scalar:** `ApiKey` header scheme alongside JWT/OAuth2.
+- Auth docs cover M2M edge auth without replacing broker/storage.
+- **AI context (vibecoding):** in `kl-nest new` (prompt) and `kl-nest add ai-context cursor|github` — scaffolds `AGENTS.md` plus Cursor rules / Copilot instructions for the generated project (docs-first + DDD constraints). Skipped with `-y`; use `add` afterwards. Does not overwrite existing files.
+- **JWT keys in `.env`:** when choosing JWT, OAuth2 and/or API Key in `new` or `add auth`, the CLI generates an RS256 key pair (`JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` as base64) and fills `.env`. `.env.example` keeps empty placeholders; existing values are not overwritten.
+
+### Upgrade
+
+On existing projects: `kl-nest add auth api-key` (with JWT/OAuth2 already installed), optionally `--api-key-internal-subnet`. Apply the `CreateApiKey` migration and add `passport-custom` if needed.
+
+For AI context on existing projects: `kl-nest add ai-context cursor`, `github`, or both.
+
 ## 4.2.0 — Migrations and entity discovery
 
 ### What changed

--- a/libs/doc/markdown/pt/host/autenticacao.md
+++ b/libs/doc/markdown/pt/host/autenticacao.md
@@ -4,12 +4,12 @@ slug: autenticacao
 category: host
 docKey: host/autenticacao
 order: 4
-description: JWT, guards globais, rotas públicas e OAuth2 genérico.
+description: JWT, guards globais, rotas públicas, OAuth2 genérico e API Key.
 ---
 
 # Autenticação
 
-O módulo de autenticação é opcional na CLI (`kl-nest new` → **JWT** ou **OAuth2** ). Com JWT, o template inclui entidade `User`, login por e-mail/senha e emissão de tokens RS256. Com OAuth2, usuários são criados ou reutilizados após o fluxo authorization code.
+O módulo de autenticação é opcional na CLI (`kl-nest new` → **JWT**, **OAuth2** e/ou **API Key**). Com JWT, o template inclui entidade `User`, login por e-mail/senha e emissão de tokens RS256. Com OAuth2, usuários são criados ou reutilizados após o fluxo authorization code. **API Key** é aditiva (exige JWT e/ou OAuth2) e autentica chamadas machine-to-machine na borda HTTP.
 
 A instalação de auth **não** altera `data-source-factory.ts`: a entidade `User` entra no DataSource via `@Entity` (DbContext) e o `UserRepository` é registrado no `RepositoryModule`.
 
@@ -18,7 +18,7 @@ A instalação de auth **não** altera `data-source-factory.ts`: a entidade `Use
 | Peça | Função |
 | --- | --- |
 | `SecurityModule` | Configura JWT RS256, Passport e serviços de token/OAuth2 |
-| `AuthGuard` | Guard global — valida Bearer token |
+| `AuthGuard` | Guard global — valida Bearer JWT e/ou header `ApiKey` |
 | `ProfilesGuard` | Guard global — restringe por perfil do token |
 | `@IsPublic()` | Marca rotas que ignoram o `AuthGuard` |
 | `@RestrictionByProfile([AuthProfile.admin])` | Restringe endpoint aos perfis informados |
@@ -252,12 +252,37 @@ app.useGlobalGuards(
 
 O bootstrap de jobs inscreve handlers de eventos e inicia CronJobs apenas quando `CRON_JOBS_ENABLED=true`. O atraso antes de iniciar os jobs é controlado por `BOOTSTRAP_DELAY_MS`.
 
+## API Key (M2M)
+
+API Key autentica callers HTTP síncronos (integrações, BFF, hops pontuais entre serviços). **Não** substitui broker/eventos nem obriga proxy de arquivos — storage em cloud + mensageria continuam a escolha preferível para domínio escalável. A strategy fica no host; handlers só veem o usuário já autenticado via `ILoggedUserInfoService`.
+
+CLI: `--auth jwt,api-key` (ou `oauth2,api-key` / `jwt,oauth2,api-key`). Flag opcional `--api-key-internal-subnet` libera IPs privados (RFC1918) no tipo `domain` para pods no cluster.
+
+### CRUD e token
+
+- Endpoints em `/api-key` (criar/listar/ler/atualizar/excluir), escopados ao usuário autenticado
+- Na criação, a chave é um JWT RS256 com `typ: api-key`, `sub` = userId, `iss` = id da chave — retornada **só** neste response
+- Uso: header `ApiKey: <jwt>`
+
+### Tipos de origem (`origin` CSV)
+
+| Tipo | Validação |
+| --- | --- |
+| `host` | `req.hostname` na lista |
+| `uri` | hostname + path (sem params de rota) |
+| `domain` | IP do cliente vs IP cadastrado **ou** domínio (reverse DNS / resolve A/AAAA). Sem headers `Origin`/`Referer` |
+
+`*` na lista libera só em `develop`/`test`. Com subnet interna habilitada, IPs privados também passam no tipo `domain` sem cadastrar cada pod.
+
+Configure `trust proxy` se a API estiver atrás de load balancer / ingress.
+
 ## Autenticacao no Scalar
 
-Com autenticação instalada, o Scalar obtém o JWT automaticamente via `authentication` no `apiReference`:
+Com autenticação instalada, o Scalar obtém credenciais via `authentication` no `apiReference`:
 
 - **JWT:** esquema **JWT** (fluxo password) → `POST /auth/login`
 - **OAuth2:** um esquema por provider (authorization code) → `POST /oauth2/scalar-token`
+- **API Key:** esquema **ApiKey** (header `ApiKey`)
 
 Guia completo: [OpenAPI com Scalar](./openapi-scalar.md#autenticacao-automatica-no-scalar)
 

--- a/libs/doc/markdown/pt/inicio/guia-de-instalacao.md
+++ b/libs/doc/markdown/pt/inicio/guia-de-instalacao.md
@@ -47,8 +47,11 @@ O comando `new` pergunta:
 - nome do projeto;
 - gerenciador de pacotes (`bun`, `npm` ou `pnpm` — Bun recomendado);
 - template (**Padrão** ou **Exemplo de CRUD**);
-- estratégia de autenticação (**JWT** ou **OAuth2** — no CRUD, auth é obrigatória);
-- funcionalidades extras (no **Padrão**: cache, health, cron, eventos; no **CRUD**: apenas health check — auth, cache Redis e jobs já vêm incluídos).
+- estratégia de autenticação (**JWT**, **OAuth2** e/ou **API Key** — no CRUD, auth é obrigatória; API Key é aditiva);
+- funcionalidades extras (no **Padrão**: cache, health, cron, eventos; no **CRUD**: apenas health check — auth, cache Redis e jobs já vêm incluídos);
+- **contexto AI** para vibecoding: **Cursor** (`.cursor/rules` + `AGENTS.md`), **GitHub Copilot** (`.github/copilot-instructions.md` + `AGENTS.md`), ambos ou nenhum.
+
+Com `-y` / `--yes`, o contexto AI **não** é gerado (mesmo padrão de features vazias). Depois você pode rodar `kl-nest add ai-context cursor` (e/ou `github`).
 
 O módulo **core** instala apenas o essencial (`@koalarx/utils`, `@nestjs/config`, `@nestjs/swagger`, `typeorm`, `pg`, `zod`, `@scalar/nestjs-api-reference`). Dependências extras entram conforme as opções marcadas:
 
@@ -84,6 +87,9 @@ kl-nest add
 kl-nest add cache
 kl-nest add auth jwt
 kl-nest add health cron events
+kl-nest add ai-context cursor
+kl-nest add ai-context github
+kl-nest add ai-context cursor github
 ```
 
 | Item | Comando | Observação |
@@ -94,6 +100,8 @@ kl-nest add health cron events
 | Health check | `kl-nest add health` | Terminus: ping PostgreSQL + Redis (se configurado) |
 | Cron jobs | `kl-nest add cron` | Requer cache em memória (instalado automaticamente) |
 | Event jobs | `kl-nest add events` | No CRUD, restaura handlers de exemplo |
+| Contexto AI (Cursor) | `kl-nest add ai-context cursor` | `AGENTS.md` + `.cursor/rules` (não sobrescreve arquivos existentes) |
+| Contexto AI (Copilot) | `kl-nest add ai-context github` | `AGENTS.md` + `.github/copilot-instructions.md` |
 
 ## Templates
 
@@ -103,7 +111,7 @@ kl-nest add health cron events
 
 ## Variáveis de ambiente
 
-Após criar o projeto, configure um `.env` na raiz:
+Após criar o projeto, a CLI já gera um `.env` a partir do `.env.example` (com `DATABASE_URL` ajustada ao nome do projeto). Com autenticação JWT / OAuth2 / API Key, as chaves `JWT_PRIVATE_KEY` e `JWT_PUBLIC_KEY` também são geradas automaticamente no `.env`.
 
 ```env
 PORT=3000

--- a/libs/doc/markdown/pt/inicio/variaveis-de-ambiente.md
+++ b/libs/doc/markdown/pt/inicio/variaveis-de-ambiente.md
@@ -44,7 +44,7 @@ export const envSchema = z.object({
 
 ## Arquivo `.env`
 
-Crie um `.env` na raiz do projeto (a CLI também copia `.env.example` como referência):
+A CLI cria o `.env` a partir do `.env.example` no `kl-nest new`. Com auth (JWT / OAuth2 / API Key), as chaves JWT já vêm preenchidas no `.env` (o exemplo permanece vazio):
 
 ```env
 PORT=3000
@@ -77,6 +77,8 @@ Já vêm no core via `applyHttpMiddleware`. Guia completo: [Middleware HTTP](../
 | `BCRYPT_ROUNDS` | Custo do hash de senha (default `10`) |
 
 ### Autenticação (quando instalada)
+
+Com `kl-nest new --auth jwt` (ou `api-key` / OAuth2) e `kl-nest add auth …`, a CLI gera um par RS256 e preenche `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` no `.env` (base64). O `.env.example` continua com placeholders vazios. Valores já preenchidos no `.env` não são sobrescritos.
 
 ```env
 JWT_PRIVATE_KEY=<chave privada RS256 em base64>

--- a/libs/doc/markdown/pt/intro/patch-notes.md
+++ b/libs/doc/markdown/pt/intro/patch-notes.md
@@ -13,6 +13,24 @@ Changelog voltado a quem usa ou atualiza projetos gerados pela CLI. Detalhes té
 
 A versão publicada do pacote `@koalarx/nest` aparece no site e no `package.json` do repositório. O arquivo [`CHANGELOG.md`](https://github.com/igordrangel/koala-nest/blob/main/CHANGELOG.md) na raiz espelha estas notas.
 
+## 4.3.0 — API Key (autenticação M2M)
+
+### O que mudou
+
+- **Nova estratégia aditiva `api-key`:** use com JWT e/ou OAuth2 (`--auth jwt,api-key`). Não pode ser escolhida sozinha.
+- **CRUD `/api-key`:** cria JWT RS256 long-lived (`typ: api-key`) e valida origem (`domain` / `host` / `uri`).
+- **Subnet interna opcional:** `--api-key-internal-subnet` (ou prompt na CLI) libera IPs privados entre pods no tipo `domain`.
+- **Scalar:** esquema `ApiKey` (header) além de JWT/OAuth2.
+- Doc de autenticação cobre o papel M2M sem substituir broker/storage.
+- **Contexto AI (vibecoding):** no `kl-nest new` (prompt) e no `kl-nest add ai-context cursor|github` — gera `AGENTS.md` e regras Cursor / instruções Copilot voltadas ao projeto gerado (docs-first + constraints DDD). Com `-y` não gera; use `add` depois. Não sobrescreve arquivos já existentes.
+- **Chaves JWT no `.env`:** ao escolher JWT, OAuth2 e/ou API Key no `new` ou no `add auth`, a CLI gera o par RS256 (`JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` em base64) e preenche o `.env`. Placeholders no `.env.example` ficam vazios; valores já preenchidos não são sobrescritos.
+
+### Upgrade
+
+Em projetos já gerados: `kl-nest add auth api-key` (com JWT/OAuth2 já instalado) e opcionalmente `--api-key-internal-subnet`. Gere/aplique a migration `CreateApiKey` e adicione `passport-custom` se necessário.
+
+Para contexto AI em projetos existentes: `kl-nest add ai-context cursor`, `github` ou ambos.
+
 ## 4.2.0 — Migrations e descoberta de entidades
 
 ### O que mudou

--- a/libs/doc/site/public/llm-en.txt
+++ b/libs/doc/site/public/llm-en.txt
@@ -43,7 +43,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.
-- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, and generic OAuth2.
+- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, generic OAuth2, and API Key.
 - [OpenAPI documentation with Scalar](markdown/en/host/openapi-scalar.md): How to configure and customize interactive documentation at /doc with Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/en/host/health-check.md): GET /health endpoint with NestJS Terminus — database and optional Redis.
 

--- a/libs/doc/site/public/llm.txt
+++ b/libs/doc/site/public/llm.txt
@@ -43,7 +43,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.
-- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas e OAuth2 genérico.
+- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas, OAuth2 genérico e API Key.
 - [Documentação OpenAPI com Scalar](markdown/pt/host/openapi-scalar.md): Como configurar e personalizar a documentação interativa em /doc com Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/pt/host/health-check.md): Endpoint GET /health com NestJS Terminus — banco e Redis opcional.
 

--- a/libs/doc/site/public/llms-en.txt
+++ b/libs/doc/site/public/llms-en.txt
@@ -43,7 +43,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.
-- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, and generic OAuth2.
+- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, generic OAuth2, and API Key.
 - [OpenAPI documentation with Scalar](markdown/en/host/openapi-scalar.md): How to configure and customize interactive documentation at /doc with Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/en/host/health-check.md): GET /health endpoint with NestJS Terminus — database and optional Redis.
 

--- a/libs/doc/site/public/llms.txt
+++ b/libs/doc/site/public/llms.txt
@@ -43,7 +43,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.
-- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas e OAuth2 genérico.
+- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas, OAuth2 genérico e API Key.
 - [Documentação OpenAPI com Scalar](markdown/pt/host/openapi-scalar.md): Como configurar e personalizar a documentação interativa em /doc com Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/pt/host/health-check.md): Endpoint GET /health com NestJS Terminus — banco e Redis opcional.
 

--- a/libs/doc/site/src/app/core/constants/app-version.ts
+++ b/libs/doc/site/src/app/core/constants/app-version.ts
@@ -1,2 +1,2 @@
 // Gerado por scripts/build-doc-manifest.mjs — não editar manualmente.
-export const APP_VERSION = '4.2.0';
+export const APP_VERSION = '4.3.0';

--- a/libs/doc/site/src/app/core/i18n/ui-copy.ts
+++ b/libs/doc/site/src/app/core/i18n/ui-copy.ts
@@ -96,7 +96,7 @@ export const UI_COPY = {
       {
         title: 'Scaffolding inteligente',
         description:
-          'Fluxo interativo para nome, gerenciador de pacotes (Bun recomendado), template, autenticação (JWT/OAuth2) e extras (cache, health, cron, eventos). API Key em breve.',
+          'Fluxo interativo para nome, gerenciador de pacotes (Bun recomendado), template, autenticação (JWT/OAuth2/API Key) e extras (cache, health, cron, eventos).',
       },
       {
         title: 'Templates úteis',
@@ -217,7 +217,7 @@ export const UI_COPY = {
       {
         title: 'Smart Scaffolding',
         description:
-          'Interactive flow for project name, package manager (Bun recommended), template, auth (JWT/OAuth2), and extras (cache, health, cron, events). API Key coming soon.',
+          'Interactive flow for project name, package manager (Bun recommended), template, auth (JWT/OAuth2/API Key), and extras (cache, health, cron, events).',
       },
       {
         title: 'Useful Templates',

--- a/libs/doc/txt/llm-en.txt
+++ b/libs/doc/txt/llm-en.txt
@@ -43,7 +43,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.
-- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, and generic OAuth2.
+- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, generic OAuth2, and API Key.
 - [OpenAPI documentation with Scalar](markdown/en/host/openapi-scalar.md): How to configure and customize interactive documentation at /doc with Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/en/host/health-check.md): GET /health endpoint with NestJS Terminus — database and optional Redis.
 

--- a/libs/doc/txt/llm.txt
+++ b/libs/doc/txt/llm.txt
@@ -43,7 +43,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.
-- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas e OAuth2 genérico.
+- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas, OAuth2 genérico e API Key.
 - [Documentação OpenAPI com Scalar](markdown/pt/host/openapi-scalar.md): Como configurar e personalizar a documentação interativa em /doc com Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/pt/host/health-check.md): Endpoint GET /health com NestJS Terminus — banco e Redis opcional.
 

--- a/libs/doc/txt/llms-en.txt
+++ b/libs/doc/txt/llms-en.txt
@@ -43,7 +43,7 @@ Documentation optimized for LLMs. Each topic links to the corresponding Markdown
 - [Controllers](markdown/en/host/controllers.md): Thin HTTP controllers that delegate to handlers.
 - [Routes and tags](markdown/en/host/routes.md): Centralized route configuration with RouterConfigBase.
 - [Error handling](markdown/en/host/error-handling.md): Global ErrorsFilter for Zod, TypeORM, and internal errors.
-- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, and generic OAuth2.
+- [Authentication](markdown/en/host/authentication.md): JWT, global guards, public routes, generic OAuth2, and API Key.
 - [OpenAPI documentation with Scalar](markdown/en/host/openapi-scalar.md): How to configure and customize interactive documentation at /doc with Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/en/host/health-check.md): GET /health endpoint with NestJS Terminus — database and optional Redis.
 

--- a/libs/doc/txt/llms.txt
+++ b/libs/doc/txt/llms.txt
@@ -43,7 +43,7 @@ Documentação otimizada para LLMs. Cada tópico aponta para o arquivo Markdown 
 - [Controllers](markdown/pt/host/controllers.md): Controllers HTTP finos que delegam para handlers.
 - [Rotas e tags](markdown/pt/host/rotas.md): Configuração centralizada de rotas com RouterConfigBase.
 - [Tratamento de erros](markdown/pt/host/tratamento-de-erros.md): Filtro global ErrorsFilter para Zod, TypeORM e erros internos.
-- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas e OAuth2 genérico.
+- [Autenticação](markdown/pt/host/autenticacao.md): JWT, guards globais, rotas públicas, OAuth2 genérico e API Key.
 - [Documentação OpenAPI com Scalar](markdown/pt/host/openapi-scalar.md): Como configurar e personalizar a documentação interativa em /doc com Scalar (OpenAPI via @nestjs/swagger).
 - [Health check](markdown/pt/host/health-check.md): Endpoint GET /health com NestJS Terminus — banco e Redis opcional.
 

--- a/libs/koala-nest/bun.lock
+++ b/libs/koala-nest/bun.lock
@@ -21,6 +21,7 @@
         "cron-parser": "^5.5.0",
         "ioredis": "^5.11.1",
         "passport": "^0.7.0",
+        "passport-custom": "^1.1.1",
         "passport-jwt": "^4.0.1",
         "pg": "^8.21.0",
         "reflect-metadata": "^0.2.2",
@@ -1158,6 +1159,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "passport": ["passport@0.7.0", "", { "dependencies": { "passport-strategy": "1.x.x", "pause": "0.0.1", "utils-merge": "^1.0.1" } }, "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ=="],
+
+    "passport-custom": ["passport-custom@1.1.1", "", { "dependencies": { "passport-strategy": "1.x.x" } }, "sha512-/2m7jUGxmCYvoqenLB9UrmkCgPt64h8ZtV+UtuQklZ/Tn1NpKBeOorCYkB/8lMRoiZ5hUrCoMmDtxCS/d38mlg=="],
 
     "passport-jwt": ["passport-jwt@4.0.1", "", { "dependencies": { "jsonwebtoken": "^9.0.0", "passport-strategy": "^1.0.0" } }, "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ=="],
 

--- a/libs/koala-nest/package.json
+++ b/libs/koala-nest/package.json
@@ -41,6 +41,7 @@
     "cron-parser": "^5.5.0",
     "ioredis": "^5.11.1",
     "passport": "^0.7.0",
+    "passport-custom": "^1.1.1",
     "passport-jwt": "^4.0.1",
     "pg": "^8.21.0",
     "reflect-metadata": "^0.2.2",

--- a/libs/koala-nest/src/application/api-key/common/persist-api-key.request.ts
+++ b/libs/koala-nest/src/application/api-key/common/persist-api-key.request.ts
@@ -1,0 +1,19 @@
+import { ObjectClass } from '@/core/base/object-class';
+import { AutoMap } from '@/core/tools/mapping';
+import { ApiKeyType } from '@/domain/entities/api-key/enums/api-key-type.enum';
+import { ApiPropertyEnum } from '@/host/decorators/api-property-enum.decorator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PersistApiKeyRequest extends ObjectClass<PersistApiKeyRequest> {
+  @ApiProperty({
+    example: '203.0.113.10,api.parceiro.com',
+    description:
+      'Lista CSV. Para type=domain: IPs e/ou domínios. Para host: hostnames. Para uri: hostname+path.',
+  })
+  @AutoMap()
+  origin: string;
+
+  @ApiPropertyEnum({ enum: ApiKeyType })
+  @AutoMap()
+  type: ApiKeyType;
+}

--- a/libs/koala-nest/src/application/api-key/common/persist-api-key.schema.ts
+++ b/libs/koala-nest/src/application/api-key/common/persist-api-key.schema.ts
@@ -1,0 +1,7 @@
+import { ApiKeyType } from '@/domain/entities/api-key/enums/api-key-type.enum';
+import { z } from 'zod';
+
+export const persistApiKeySchema = z.object({
+  origin: z.string().min(1),
+  type: z.enum([ApiKeyType.domain, ApiKeyType.host, ApiKeyType.uri]),
+});

--- a/libs/koala-nest/src/application/api-key/common/persist-api-key.validator.ts
+++ b/libs/koala-nest/src/application/api-key/common/persist-api-key.validator.ts
@@ -1,0 +1,9 @@
+import { RequestValidatorBase } from '@/application/common/request-validator.base';
+import { persistApiKeySchema } from './persist-api-key.schema';
+import { PersistApiKeyRequest } from './persist-api-key.request';
+
+export class PersistApiKeyValidator extends RequestValidatorBase<PersistApiKeyRequest> {
+  protected get schema() {
+    return persistApiKeySchema;
+  }
+}

--- a/libs/koala-nest/src/application/api-key/create/create-api-key.handler.ts
+++ b/libs/koala-nest/src/application/api-key/create/create-api-key.handler.ts
@@ -1,0 +1,57 @@
+import { PersistApiKeyValidator } from '@/application/api-key/common/persist-api-key.validator';
+import { RequestHandlerBase } from '@/application/common/request-handler.base';
+import { AuthHttp } from '@/core/auth/auth.constants';
+import { AutoMapper } from '@/core/tools/mapping';
+import { ApiKey } from '@/domain/entities/api-key/api-key';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { ILoggedUserInfoService } from '@/domain/services/ilogged-user-info.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { CreateApiKeyRequest } from './create-api-key.request';
+import { CreateApiKeyResponse } from './create-api-key.response';
+
+@Injectable()
+export class CreateApiKeyHandler extends RequestHandlerBase<
+  CreateApiKeyRequest,
+  CreateApiKeyResponse
+> {
+  constructor(
+    private readonly loggedUser: ILoggedUserInfoService,
+    private readonly repository: IApiKeyRepository,
+    private readonly jwt: JwtService,
+  ) {
+    super();
+  }
+
+  async handle(req: CreateApiKeyRequest): Promise<CreateApiKeyResponse> {
+    const validated = new PersistApiKeyValidator(req).validate();
+    const user = this.loggedUser.getUser();
+
+    const apiKey = AutoMapper.map(validated, CreateApiKeyRequest, ApiKey);
+    apiKey.userId = user.sub;
+    apiKey.key = '';
+
+    const saved = await this.repository.save(apiKey);
+    const created = await this.repository.findById(saved.id);
+
+    if (!created) {
+      throw new NotFoundException('Chave de API após criação');
+    }
+
+    created.key = await this.jwt.signAsync(
+      {
+        sub: created.userId,
+        iss: created.id,
+        typ: AuthHttp.API_KEY_TOKEN_TYPE,
+      },
+      {
+        expiresIn: '100y',
+        algorithm: AuthHttp.JWT_ALGORITHM,
+      },
+    );
+
+    await this.repository.save(created);
+
+    return CreateApiKeyResponse.from({ id: created.id, key: created.key });
+  }
+}

--- a/libs/koala-nest/src/application/api-key/create/create-api-key.handler.ts
+++ b/libs/koala-nest/src/application/api-key/create/create-api-key.handler.ts
@@ -38,7 +38,7 @@ export class CreateApiKeyHandler extends RequestHandlerBase<
       throw new NotFoundException('Chave de API após criação');
     }
 
-    created.key = await this.jwt.signAsync(
+    const key = await this.jwt.signAsync(
       {
         sub: created.userId,
         iss: created.id,
@@ -50,8 +50,7 @@ export class CreateApiKeyHandler extends RequestHandlerBase<
       },
     );
 
-    await this.repository.save(created);
-
-    return CreateApiKeyResponse.from({ id: created.id, key: created.key });
+    // JWT só na resposta da criação — auth usa assinatura + iss (linha), não a coluna.
+    return CreateApiKeyResponse.from({ id: created.id, key });
   }
 }

--- a/libs/koala-nest/src/application/api-key/create/create-api-key.request.ts
+++ b/libs/koala-nest/src/application/api-key/create/create-api-key.request.ts
@@ -1,0 +1,3 @@
+import { PersistApiKeyRequest } from '@/application/api-key/common/persist-api-key.request';
+
+export class CreateApiKeyRequest extends PersistApiKeyRequest {}

--- a/libs/koala-nest/src/application/api-key/create/create-api-key.response.ts
+++ b/libs/koala-nest/src/application/api-key/create/create-api-key.response.ts
@@ -1,0 +1,15 @@
+import { ObjectClass } from '@/core/base/object-class';
+import { AutoMap } from '@/core/tools/mapping';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateApiKeyResponse extends ObjectClass<CreateApiKeyResponse> {
+  @ApiProperty({ type: 'string', format: 'uuid' })
+  @AutoMap()
+  id: string;
+
+  @ApiProperty({
+    description: 'JWT da API Key — exibido apenas neste response de criação.',
+  })
+  @AutoMap()
+  key: string;
+}

--- a/libs/koala-nest/src/application/api-key/delete/delete-api-key.handler.ts
+++ b/libs/koala-nest/src/application/api-key/delete/delete-api-key.handler.ts
@@ -1,0 +1,25 @@
+import { findApiKeyOrThrow } from '@/application/api-key/find-api-key-or-throw';
+import { RequestHandlerBase } from '@/application/common/request-handler.base';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { ILoggedUserInfoService } from '@/domain/services/ilogged-user-info.service';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DeleteApiKeyHandler extends RequestHandlerBase<string, void> {
+  constructor(
+    private readonly repository: IApiKeyRepository,
+    private readonly loggedUser: ILoggedUserInfoService,
+  ) {
+    super();
+  }
+
+  async handle(id: string): Promise<void> {
+    const apiKey = await findApiKeyOrThrow(
+      this.repository,
+      id,
+      this.loggedUser.getUser().sub,
+    );
+
+    await this.repository.delete(apiKey);
+  }
+}

--- a/libs/koala-nest/src/application/api-key/find-api-key-or-throw.ts
+++ b/libs/koala-nest/src/application/api-key/find-api-key-or-throw.ts
@@ -1,0 +1,17 @@
+import { ApiKey } from '@/domain/entities/api-key/api-key';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { NotFoundException } from '@nestjs/common';
+
+export async function findApiKeyOrThrow(
+  repository: IApiKeyRepository,
+  id: string,
+  userId: string,
+): Promise<ApiKey> {
+  const apiKey = await repository.findByIdForUser(id, userId);
+
+  if (!apiKey) {
+    throw new NotFoundException('API Key não encontrada');
+  }
+
+  return apiKey;
+}

--- a/libs/koala-nest/src/application/api-key/read-many/read-many-api-key.handler.ts
+++ b/libs/koala-nest/src/application/api-key/read-many/read-many-api-key.handler.ts
@@ -1,0 +1,36 @@
+import { RequestHandlerBase } from '@/application/common/request-handler.base';
+import { AutoMapper } from '@/core/tools/mapping';
+import { ApiKey } from '@/domain/entities/api-key/api-key';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { ILoggedUserInfoService } from '@/domain/services/ilogged-user-info.service';
+import { Injectable } from '@nestjs/common';
+import {
+  ReadManyApiKeyResponse,
+  ReadManyApiKeyResponseItem,
+} from './read-many-api-key.response';
+
+@Injectable()
+export class ReadManyApiKeyHandler extends RequestHandlerBase<
+  void,
+  ReadManyApiKeyResponse
+> {
+  constructor(
+    private readonly repository: IApiKeyRepository,
+    private readonly loggedUser: ILoggedUserInfoService,
+  ) {
+    super();
+  }
+
+  async handle(): Promise<ReadManyApiKeyResponse> {
+    const result = await this.repository.findManyByUserId(
+      this.loggedUser.getUser().sub,
+    );
+
+    return ReadManyApiKeyResponse.from({
+      items: result.items.map((item) =>
+        AutoMapper.map(item, ApiKey, ReadManyApiKeyResponseItem),
+      ),
+      count: result.count,
+    });
+  }
+}

--- a/libs/koala-nest/src/application/api-key/read-many/read-many-api-key.response.ts
+++ b/libs/koala-nest/src/application/api-key/read-many/read-many-api-key.response.ts
@@ -1,0 +1,12 @@
+import { ListResponseBase } from '@/core/common/list-response.base';
+import { AutoMap } from '@/core/tools/mapping';
+import { ReadApiKeyResponse } from '@/application/api-key/read/read-api-key.response';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReadManyApiKeyResponseItem extends ReadApiKeyResponse {}
+
+export class ReadManyApiKeyResponse extends ListResponseBase<ReadManyApiKeyResponseItem> {
+  @ApiProperty({ type: ReadManyApiKeyResponseItem, isArray: true })
+  @AutoMap({ type: () => ReadManyApiKeyResponseItem })
+  declare items: ReadManyApiKeyResponseItem[];
+}

--- a/libs/koala-nest/src/application/api-key/read/read-api-key.handler.ts
+++ b/libs/koala-nest/src/application/api-key/read/read-api-key.handler.ts
@@ -1,0 +1,31 @@
+import { RequestHandlerBase } from '@/application/common/request-handler.base';
+import { findApiKeyOrThrow } from '@/application/api-key/find-api-key-or-throw';
+import { AutoMapper } from '@/core/tools/mapping';
+import { ApiKey } from '@/domain/entities/api-key/api-key';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { ILoggedUserInfoService } from '@/domain/services/ilogged-user-info.service';
+import { Injectable } from '@nestjs/common';
+import { ReadApiKeyResponse } from './read-api-key.response';
+
+@Injectable()
+export class ReadApiKeyHandler extends RequestHandlerBase<
+  string,
+  ReadApiKeyResponse
+> {
+  constructor(
+    private readonly repository: IApiKeyRepository,
+    private readonly loggedUser: ILoggedUserInfoService,
+  ) {
+    super();
+  }
+
+  async handle(id: string): Promise<ReadApiKeyResponse> {
+    const apiKey = await findApiKeyOrThrow(
+      this.repository,
+      id,
+      this.loggedUser.getUser().sub,
+    );
+
+    return AutoMapper.map(apiKey, ApiKey, ReadApiKeyResponse);
+  }
+}

--- a/libs/koala-nest/src/application/api-key/read/read-api-key.response.ts
+++ b/libs/koala-nest/src/application/api-key/read/read-api-key.response.ts
@@ -1,0 +1,22 @@
+import { AutoMap } from '@/core/tools/mapping';
+import { ApiKeyType } from '@/domain/entities/api-key/enums/api-key-type.enum';
+import { ApiPropertyEnum } from '@/host/decorators/api-property-enum.decorator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReadApiKeyResponse {
+  @ApiProperty({ format: 'uuid' })
+  @AutoMap()
+  id: string;
+
+  @ApiPropertyEnum({ enum: ApiKeyType })
+  @AutoMap()
+  type: ApiKeyType;
+
+  @ApiProperty()
+  @AutoMap()
+  origin: string;
+
+  @ApiProperty()
+  @AutoMap()
+  createdAt: Date;
+}

--- a/libs/koala-nest/src/application/api-key/update/update-api-key.handler.ts
+++ b/libs/koala-nest/src/application/api-key/update/update-api-key.handler.ts
@@ -1,0 +1,34 @@
+import { findApiKeyOrThrow } from '@/application/api-key/find-api-key-or-throw';
+import { RequestHandlerBase } from '@/application/common/request-handler.base';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { ILoggedUserInfoService } from '@/domain/services/ilogged-user-info.service';
+import { Injectable } from '@nestjs/common';
+import { UpdateApiKeyRequest } from './update-api-key.request';
+import { UpdateApiKeyValidator } from './update-api-key.validator';
+
+@Injectable()
+export class UpdateApiKeyHandler extends RequestHandlerBase<
+  UpdateApiKeyRequest,
+  void
+> {
+  constructor(
+    private readonly repository: IApiKeyRepository,
+    private readonly loggedUser: ILoggedUserInfoService,
+  ) {
+    super();
+  }
+
+  async handle(request: UpdateApiKeyRequest): Promise<void> {
+    const validated = new UpdateApiKeyValidator(request).validate();
+    const apiKey = await findApiKeyOrThrow(
+      this.repository,
+      validated.id,
+      this.loggedUser.getUser().sub,
+    );
+
+    apiKey.origin = validated.origin;
+    apiKey.type = validated.type;
+
+    await this.repository.save(apiKey);
+  }
+}

--- a/libs/koala-nest/src/application/api-key/update/update-api-key.request.ts
+++ b/libs/koala-nest/src/application/api-key/update/update-api-key.request.ts
@@ -1,0 +1,9 @@
+import { PersistApiKeyRequest } from '@/application/api-key/common/persist-api-key.request';
+import { AutoMap } from '@/core/tools/mapping';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateApiKeyRequest extends PersistApiKeyRequest {
+  @ApiProperty({ format: 'uuid' })
+  @AutoMap()
+  id: string;
+}

--- a/libs/koala-nest/src/application/api-key/update/update-api-key.validator.ts
+++ b/libs/koala-nest/src/application/api-key/update/update-api-key.validator.ts
@@ -1,0 +1,12 @@
+import { RequestValidatorBase } from '@/application/common/request-validator.base';
+import { persistApiKeySchema } from '@/application/api-key/common/persist-api-key.schema';
+import { UpdateApiKeyRequest } from './update-api-key.request';
+import { z } from 'zod';
+
+export class UpdateApiKeyValidator extends RequestValidatorBase<UpdateApiKeyRequest> {
+  protected get schema() {
+    return persistApiKeySchema.extend({
+      id: z.uuid(),
+    });
+  }
+}

--- a/libs/koala-nest/src/application/mapping/api-key.mapper.ts
+++ b/libs/koala-nest/src/application/mapping/api-key.mapper.ts
@@ -1,0 +1,15 @@
+import { createMap } from '@/core/tools/mapping';
+import { CreateApiKeyRequest } from '@/application/api-key/create/create-api-key.request';
+import { CreateApiKeyResponse } from '@/application/api-key/create/create-api-key.response';
+import { ReadApiKeyResponse } from '@/application/api-key/read/read-api-key.response';
+import { ReadManyApiKeyResponseItem } from '@/application/api-key/read-many/read-many-api-key.response';
+import { ApiKey } from '@/domain/entities/api-key/api-key';
+
+export class ApiKeyMapper {
+  static createMap() {
+    createMap(CreateApiKeyRequest, ApiKey);
+    createMap(ApiKey, CreateApiKeyResponse);
+    createMap(ApiKey, ReadApiKeyResponse);
+    createMap(ApiKey, ReadManyApiKeyResponseItem);
+  }
+}

--- a/libs/koala-nest/src/application/mapping/mapping.provider.ts
+++ b/libs/koala-nest/src/application/mapping/mapping.provider.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import { ApiKeyMapper } from './api-key.mapper';
 import { PersonMapper } from './person.mapper';
 
 @Injectable()
 export class MappingProvider {
   constructor() {
     PersonMapper.createMap();
+    ApiKeyMapper.createMap();
   }
 }

--- a/libs/koala-nest/src/core/auth/auth.constants.ts
+++ b/libs/koala-nest/src/core/auth/auth.constants.ts
@@ -3,4 +3,6 @@ export const AuthHttp = {
   BEARER_PREFIX: 'Bearer ',
   REFRESH_TOKEN_COOKIE: 'refreshToken',
   JWT_ALGORITHM: 'RS256',
+  API_KEY_HEADER: 'ApiKey',
+  API_KEY_TOKEN_TYPE: 'api-key',
 } as const;

--- a/libs/koala-nest/src/core/utils/capture-apikey-on-request.ts
+++ b/libs/koala-nest/src/core/utils/capture-apikey-on-request.ts
@@ -1,0 +1,13 @@
+import { AuthHttp } from '@/core/auth/auth.constants';
+import { Request } from 'express';
+
+/** Lê o header `ApiKey` (case-insensitive via Express). */
+export function captureApiKeyOnRequest(request: Request): string | undefined {
+  const value = request.headers[AuthHttp.API_KEY_HEADER.toLowerCase()];
+
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return typeof value === 'string' ? value : undefined;
+}

--- a/libs/koala-nest/src/core/utils/internal-subnet-validator.ts
+++ b/libs/koala-nest/src/core/utils/internal-subnet-validator.ts
@@ -1,0 +1,47 @@
+import net from 'node:net';
+
+/**
+ * Libera IPs de redes privadas (RFC1918 / IPv6 ULA e link-local).
+ * Útil para hops HTTP entre pods no mesmo cluster — opcional via CLI.
+ */
+export class InternalSubnetValidator {
+  static validate(ip: string): boolean {
+    let normalized = ip;
+
+    if (normalized.substring(0, 7) === '::ffff:') {
+      normalized = normalized.substring(7);
+    }
+
+    if (net.isIPv4(normalized)) {
+      return (
+        /^(10)\.(.*)\.(.*)\.(.*)$/.test(normalized) ||
+        /^(172)\.(1[6-9]|2[0-9]|3[0-1])\.(.*)\.(.*)$/.test(normalized) ||
+        /^(192)\.(168)\.(.*)\.(.*)$/.test(normalized)
+      );
+    }
+
+    const firstWord = normalized.split(':').find((el) => !!el) ?? '';
+
+    if (/^fe[c-f][0-f]$/.test(firstWord)) {
+      return true;
+    }
+
+    if (/^fc[0-f]{2}$/.test(firstWord)) {
+      return true;
+    }
+
+    if (/^fd[0-f]{2}$/.test(firstWord)) {
+      return true;
+    }
+
+    if (firstWord === 'fe80') {
+      return true;
+    }
+
+    if (firstWord === '100') {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/libs/koala-nest/src/core/utils/match-api-key-domain-origin.ts
+++ b/libs/koala-nest/src/core/utils/match-api-key-domain-origin.ts
@@ -1,0 +1,77 @@
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
+function stripIpv4Mapped(ip: string) {
+  if (ip.startsWith('::ffff:')) {
+    return ip.substring(7);
+  }
+
+  return ip;
+}
+
+function hostnameMatches(registered: string, hostnames: string[]) {
+  const needle = registered.toLowerCase().replace(/\.$/, '');
+
+  return hostnames.some((hostname) => {
+    const candidate = hostname.toLowerCase().replace(/\.$/, '');
+    return candidate === needle || candidate.endsWith(`.${needle}`);
+  });
+}
+
+/**
+ * Valida origem tipo `domain`: item cadastrado pode ser IP ou hostname.
+ * - IP → match exato com o IP do cliente
+ * - domínio → reverse DNS do cliente ou A/AAAA do domínio inclui o IP
+ */
+export async function matchApiKeyDomainOrigin(
+  clientIp: string,
+  origins: string[],
+): Promise<boolean> {
+  const ip = stripIpv4Mapped(clientIp);
+
+  if (!ip) {
+    return false;
+  }
+
+  for (const raw of origins) {
+    const origin = raw.trim();
+
+    if (!origin || origin === '*') {
+      continue;
+    }
+
+    if (net.isIP(origin)) {
+      if (stripIpv4Mapped(origin) === ip) {
+        return true;
+      }
+
+      continue;
+    }
+
+    const reverseHosts = await dns.reverse(ip).catch(() => [] as string[]);
+
+    if (hostnameMatches(origin, reverseHosts)) {
+      return true;
+    }
+
+    const resolved = await dns
+      .lookup(origin, { all: true })
+      .then((entries) => entries.map((entry) => entry.address))
+      .catch(() => [] as string[]);
+
+    if (resolved.some((address) => stripIpv4Mapped(address) === ip)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function resolveClientIp(request: {
+  ip?: string;
+  socket?: { remoteAddress?: string };
+}): string | undefined {
+  const raw = request.ip || request.socket?.remoteAddress;
+
+  return raw ? stripIpv4Mapped(raw) : undefined;
+}

--- a/libs/koala-nest/src/domain/entities/api-key/api-key.ts
+++ b/libs/koala-nest/src/domain/entities/api-key/api-key.ts
@@ -26,8 +26,8 @@ export class ApiKey extends EntityBase<ApiKey> {
   @AutoMap()
   origin: string;
 
-  /** JWT RS256 com typ=api-key — exposto apenas na criação. */
-  @Column()
+  /** Legado/vazio: o JWT é devolvido só na criação; auth valida assinatura + `iss`. */
+  @Column({ default: '' })
   key: string;
 
   @Column({ name: 'user_id' })

--- a/libs/koala-nest/src/domain/entities/api-key/api-key.ts
+++ b/libs/koala-nest/src/domain/entities/api-key/api-key.ts
@@ -1,0 +1,44 @@
+import { EntityBase } from '@/core/base/entity.base';
+import { Entity } from '@/core/database/entity';
+import { AutoMap } from '@/core/tools/mapping';
+import { User } from '@/domain/entities/user/user';
+import { ApiKeyType } from './enums/api-key-type.enum';
+import {
+  Column,
+  CreateDateColumn,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('api_key')
+export class ApiKey extends EntityBase<ApiKey> {
+  @PrimaryGeneratedColumn('uuid')
+  @AutoMap()
+  id: string;
+
+  @Column({ type: 'varchar' })
+  @AutoMap()
+  type: ApiKeyType;
+
+  /** Lista CSV de IPs e/ou domínios (domain), hosts ou URIs conforme `type`. */
+  @Column()
+  @AutoMap()
+  origin: string;
+
+  /** JWT RS256 com typ=api-key — exposto apenas na criação. */
+  @Column()
+  key: string;
+
+  @Column({ name: 'user_id' })
+  @AutoMap()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @CreateDateColumn({ name: 'created_at' })
+  @AutoMap()
+  createdAt: Date;
+}

--- a/libs/koala-nest/src/domain/entities/api-key/enums/api-key-type.enum.ts
+++ b/libs/koala-nest/src/domain/entities/api-key/enums/api-key-type.enum.ts
@@ -1,0 +1,11 @@
+/**
+ * Como a origem da API Key é validada na strategy.
+ * - domain: IP do cliente vs IP/domínio cadastrado (+ subnet interna opcional)
+ * - host: hostname da requisição
+ * - uri: hostname + path (sem params de rota)
+ */
+export enum ApiKeyType {
+  domain = 'domain',
+  host = 'host',
+  uri = 'uri',
+}

--- a/libs/koala-nest/src/domain/repositories/iapi-key.repository.ts
+++ b/libs/koala-nest/src/domain/repositories/iapi-key.repository.ts
@@ -1,0 +1,10 @@
+import { ListResponse } from '@/core/types';
+import { ApiKey } from '../entities/api-key/api-key';
+
+export abstract class IApiKeyRepository {
+  abstract findByIdForUser(id: string, userId: string): Promise<ApiKey | null>;
+  abstract findById(id: string): Promise<ApiKey | null>;
+  abstract findManyByUserId(userId: string): Promise<ListResponse<ApiKey>>;
+  abstract save(apiKey: ApiKey): Promise<ApiKey>;
+  abstract delete(apiKey: ApiKey): Promise<void>;
+}

--- a/libs/koala-nest/src/host/app.module.ts
+++ b/libs/koala-nest/src/host/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { InactivePersonHandler } from '@/application/person/jobs/events/person/inactive-person/inactive-person.handler';
 import { CreatePersonJob } from '@/application/person/jobs/cron/create-person.job';
 import { DeleteInactiveJob } from '@/application/person/jobs/cron/delete-inactive.job';
+import { ApiKeyModule } from './controllers/api-key/api-key.module';
 import { AuthModule } from './controllers/auth/auth.module';
 import { JobsModule } from './jobs/jobs.module';
 import { PersonModule } from './controllers/person/person.module';
@@ -17,6 +18,7 @@ import { SecurityModule } from './security/security.module';
     }),
     SecurityModule,
     AuthModule,
+    ApiKeyModule,
     JobsModule.register({
       imports: [PersonModule],
       eventHandlers: [InactivePersonHandler],

--- a/libs/koala-nest/src/host/controllers/api-key/api-key.module.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/api-key.module.ts
@@ -1,0 +1,31 @@
+import { CreateApiKeyHandler } from '@/application/api-key/create/create-api-key.handler';
+import { DeleteApiKeyHandler } from '@/application/api-key/delete/delete-api-key.handler';
+import { ReadManyApiKeyHandler } from '@/application/api-key/read-many/read-many-api-key.handler';
+import { ReadApiKeyHandler } from '@/application/api-key/read/read-api-key.handler';
+import { UpdateApiKeyHandler } from '@/application/api-key/update/update-api-key.handler';
+import { Module } from '@nestjs/common';
+import { ControllerModule } from '../common/controller.module';
+import { CreateApiKeyController } from './create-api-key.controller';
+import { DeleteApiKeyController } from './delete-api-key.controller';
+import { ReadManyApiKeyController } from './read-many-api-key.controller';
+import { ReadApiKeyController } from './read-api-key.controller';
+import { UpdateApiKeyController } from './update-api-key.controller';
+
+@Module({
+  imports: [ControllerModule],
+  controllers: [
+    CreateApiKeyController,
+    ReadManyApiKeyController,
+    ReadApiKeyController,
+    UpdateApiKeyController,
+    DeleteApiKeyController,
+  ],
+  providers: [
+    CreateApiKeyHandler,
+    ReadApiKeyHandler,
+    ReadManyApiKeyHandler,
+    UpdateApiKeyHandler,
+    DeleteApiKeyHandler,
+  ],
+})
+export class ApiKeyModule {}

--- a/libs/koala-nest/src/host/controllers/api-key/create-api-key.controller.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/create-api-key.controller.ts
@@ -1,0 +1,23 @@
+import { CreateApiKeyHandler } from '@/application/api-key/create/create-api-key.handler';
+import { CreateApiKeyRequest } from '@/application/api-key/create/create-api-key.request';
+import { CreateApiKeyResponse } from '@/application/api-key/create/create-api-key.response';
+import { Controller } from '@/host/decorators/controller.decorator';
+import { Body, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiCreatedResponse } from '@nestjs/swagger';
+import { IController } from '../common/controller.base';
+import { API_KEY_ROUTER_CONFIG } from './router.config';
+
+@Controller(API_KEY_ROUTER_CONFIG)
+export class CreateApiKeyController implements IController<
+  CreateApiKeyRequest,
+  CreateApiKeyResponse
+> {
+  constructor(private readonly handler: CreateApiKeyHandler) {}
+
+  @Post()
+  @ApiCreatedResponse({ type: CreateApiKeyResponse })
+  @HttpCode(HttpStatus.CREATED)
+  handle(@Body() request: CreateApiKeyRequest): Promise<CreateApiKeyResponse> {
+    return this.handler.handle(request);
+  }
+}

--- a/libs/koala-nest/src/host/controllers/api-key/delete-api-key.controller.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/delete-api-key.controller.ts
@@ -1,0 +1,18 @@
+import { DeleteApiKeyHandler } from '@/application/api-key/delete/delete-api-key.handler';
+import { Controller } from '@/host/decorators/controller.decorator';
+import { Delete, HttpCode, HttpStatus, Param } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { IController } from '../common/controller.base';
+import { API_KEY_ROUTER_CONFIG } from './router.config';
+
+@Controller(API_KEY_ROUTER_CONFIG)
+export class DeleteApiKeyController implements IController<string, void> {
+  constructor(private readonly handler: DeleteApiKeyHandler) {}
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOkResponse()
+  handle(@Param('id') id: string): Promise<void> {
+    return this.handler.handle(id);
+  }
+}

--- a/libs/koala-nest/src/host/controllers/api-key/read-api-key.controller.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/read-api-key.controller.ts
@@ -1,0 +1,21 @@
+import { ReadApiKeyHandler } from '@/application/api-key/read/read-api-key.handler';
+import { ReadApiKeyResponse } from '@/application/api-key/read/read-api-key.response';
+import { Controller } from '@/host/decorators/controller.decorator';
+import { Get, Param } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { IController } from '../common/controller.base';
+import { API_KEY_ROUTER_CONFIG } from './router.config';
+
+@Controller(API_KEY_ROUTER_CONFIG)
+export class ReadApiKeyController implements IController<
+  string,
+  ReadApiKeyResponse
+> {
+  constructor(private readonly handler: ReadApiKeyHandler) {}
+
+  @Get(':id')
+  @ApiOkResponse({ type: ReadApiKeyResponse })
+  handle(@Param('id') id: string): Promise<ReadApiKeyResponse> {
+    return this.handler.handle(id);
+  }
+}

--- a/libs/koala-nest/src/host/controllers/api-key/read-many-api-key.controller.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/read-many-api-key.controller.ts
@@ -1,0 +1,21 @@
+import { ReadManyApiKeyHandler } from '@/application/api-key/read-many/read-many-api-key.handler';
+import { ReadManyApiKeyResponse } from '@/application/api-key/read-many/read-many-api-key.response';
+import { Controller } from '@/host/decorators/controller.decorator';
+import { Get } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { IController } from '../common/controller.base';
+import { API_KEY_ROUTER_CONFIG } from './router.config';
+
+@Controller(API_KEY_ROUTER_CONFIG)
+export class ReadManyApiKeyController implements IController<
+  void,
+  ReadManyApiKeyResponse
+> {
+  constructor(private readonly handler: ReadManyApiKeyHandler) {}
+
+  @Get()
+  @ApiOkResponse({ type: ReadManyApiKeyResponse })
+  handle(): Promise<ReadManyApiKeyResponse> {
+    return this.handler.handle();
+  }
+}

--- a/libs/koala-nest/src/host/controllers/api-key/router.config.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/router.config.ts
@@ -1,0 +1,9 @@
+import { RouterConfigBase } from '../common/router-config.base';
+
+class ApiKeyRouterConfig extends RouterConfigBase {
+  constructor() {
+    super('ApiKey', '/api-key');
+  }
+}
+
+export const API_KEY_ROUTER_CONFIG = new ApiKeyRouterConfig();

--- a/libs/koala-nest/src/host/controllers/api-key/update-api-key.controller.ts
+++ b/libs/koala-nest/src/host/controllers/api-key/update-api-key.controller.ts
@@ -1,0 +1,22 @@
+import { UpdateApiKeyHandler } from '@/application/api-key/update/update-api-key.handler';
+import { UpdateApiKeyRequest } from '@/application/api-key/update/update-api-key.request';
+import { Controller } from '@/host/decorators/controller.decorator';
+import { Body, HttpCode, HttpStatus, Put } from '@nestjs/common';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { IController } from '../common/controller.base';
+import { API_KEY_ROUTER_CONFIG } from './router.config';
+
+@Controller(API_KEY_ROUTER_CONFIG)
+export class UpdateApiKeyController implements IController<
+  UpdateApiKeyRequest,
+  void
+> {
+  constructor(private readonly handler: UpdateApiKeyHandler) {}
+
+  @Put()
+  @ApiOkResponse()
+  @HttpCode(HttpStatus.OK)
+  handle(@Body() request: UpdateApiKeyRequest): Promise<void> {
+    return this.handler.handle(request);
+  }
+}

--- a/libs/koala-nest/src/host/open-api/define-documentation.ts
+++ b/libs/koala-nest/src/host/open-api/define-documentation.ts
@@ -1,3 +1,4 @@
+import { AuthHttp } from '@/core/auth/auth.constants';
 import { OAuthProviderRegistry } from '@/core/auth/oauth-provider.registry';
 import { EnvConfig } from '@/core/utils/env.config';
 import {
@@ -23,10 +24,12 @@ import packageJson from '../../../package.json';
 
 const DOC_ENDPOINT = '/doc';
 const ACCESS_TOKEN_FIELD = 'accessToken';
+const API_KEY_SCHEME_NAME = 'ApiKey';
 
 type DocAuthorization = {
   name: string;
   config: Record<string, unknown>;
+  kind: 'bearer' | 'apiKey';
 };
 
 function capitalizeProvider(key: string) {
@@ -82,6 +85,7 @@ async function buildDocAuthorizations(
   if (hasController(app, 'LoginController')) {
     authorizations.push({
       name: 'JWT',
+      kind: 'bearer',
       config: {
         type: 'oauth2',
         flows: {
@@ -110,6 +114,7 @@ async function buildDocAuthorizations(
 
         authorizations.push({
           name: capitalizeProvider(providerKey),
+          kind: 'bearer',
           config: {
             type: 'oauth2',
             flows: {
@@ -138,6 +143,18 @@ async function buildDocAuthorizations(
     }
   }
 
+  if (hasController(app, 'CreateApiKeyController')) {
+    authorizations.push({
+      name: API_KEY_SCHEME_NAME,
+      kind: 'apiKey',
+      config: {
+        type: 'apiKey',
+        in: 'header',
+        name: AuthHttp.API_KEY_HEADER,
+      },
+    });
+  }
+
   return authorizations;
 }
 
@@ -149,10 +166,18 @@ export async function defineDocumentation(app: INestApplication) {
     .setVersion(packageJson.version);
 
   for (const authorization of authorizations) {
-    documentBuilder.addBearerAuth(
-      authorization.config as never,
-      authorization.name,
-    );
+    if (authorization.kind === 'apiKey') {
+      documentBuilder.addApiKey(
+        authorization.config as never,
+        authorization.name,
+      );
+    } else {
+      documentBuilder.addBearerAuth(
+        authorization.config as never,
+        authorization.name,
+      );
+    }
+
     documentBuilder.addSecurityRequirements(authorization.name);
   }
 

--- a/libs/koala-nest/src/host/security/guards/auth.guard.ts
+++ b/libs/koala-nest/src/host/security/guards/auth.guard.ts
@@ -19,7 +19,7 @@ type AuthRequest = Parameters<typeof applyRefreshTokenForRefreshRoute>[0] & {
 };
 
 @Injectable()
-export class AuthGuard extends NestAuthGuard('jwt') {
+export class AuthGuard extends NestAuthGuard(['jwt', 'apikey']) {
   constructor(
     private readonly reflector: Reflector,
     private readonly userRepository: IUserRepository,

--- a/libs/koala-nest/src/host/security/security.module.ts
+++ b/libs/koala-nest/src/host/security/security.module.ts
@@ -5,6 +5,7 @@ import {
   IJwtTokenService,
   IOAuth2Service,
 } from '@/domain/auth/services/iauth.service';
+import { ApiKeyAuthorizationService } from '@/infra/auth/api-key-authorization.service';
 import { JwtTokenService } from '@/infra/auth/jwt-token.service';
 import { OAuth2AuthService } from '@/infra/auth/oauth2-auth.service';
 import { InfraModule } from '@/infra/infra.module';
@@ -12,6 +13,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ApiKeyStrategy } from './strategies/api-key.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthGuard } from './guards/auth.guard';
 import { ProfilesGuard } from './guards/profiles.guard';
@@ -45,6 +47,8 @@ import { ProfilesGuard } from './guards/profiles.guard';
   providers: [
     OAuthProviderRegistry,
     JwtStrategy,
+    ApiKeyStrategy,
+    ApiKeyAuthorizationService,
     AuthGuard,
     ProfilesGuard,
     { provide: IJwtTokenService, useClass: JwtTokenService },

--- a/libs/koala-nest/src/host/security/strategies/api-key.strategy.ts
+++ b/libs/koala-nest/src/host/security/strategies/api-key.strategy.ts
@@ -1,0 +1,75 @@
+import { AuthHttp } from '@/core/auth/auth.constants';
+import { captureApiKeyOnRequest } from '@/core/utils/capture-apikey-on-request';
+import { ApiKeyAuthorizationService } from '@/infra/auth/api-key-authorization.service';
+import { EnvService } from '@/infra/common/env.service';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PassportStrategy } from '@nestjs/passport';
+import { Request } from 'express';
+import { Strategy } from 'passport-custom';
+import { z } from 'zod';
+
+const apiKeyTokenSchema = z.object({
+  sub: z.uuid(),
+  iss: z.uuid(),
+  typ: z.string().optional().nullable(),
+});
+
+type ApiKeyToken = z.infer<typeof apiKeyTokenSchema>;
+
+type DoneFn = (err: Error | null, user?: ApiKeyToken) => void;
+
+@Injectable()
+export class ApiKeyStrategy extends PassportStrategy(Strategy, 'apikey') {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly authorizationService: ApiKeyAuthorizationService,
+    private readonly env: EnvService,
+  ) {
+    super();
+  }
+
+  async validate(req: Request, done: DoneFn) {
+    const encoded = captureApiKeyOnRequest(req);
+
+    if (!encoded) {
+      done(new UnauthorizedException());
+      return;
+    }
+
+    const publicKey = this.env.get('JWT_PUBLIC_KEY');
+
+    if (!publicKey) {
+      done(new UnauthorizedException());
+      return;
+    }
+
+    const result = await this.jwtService
+      .verifyAsync(encoded, {
+        algorithms: [AuthHttp.JWT_ALGORITHM],
+        publicKey: Buffer.from(publicKey, 'base64'),
+      })
+      .then(() => apiKeyTokenSchema.parse(this.jwtService.decode(encoded)))
+      .then(async (decodedToken) => {
+        if (decodedToken.typ !== AuthHttp.API_KEY_TOKEN_TYPE) {
+          return { validOrigin: false, decodedToken: null };
+        }
+
+        const validOrigin = await this.authorizationService.validateApiKey(
+          decodedToken.sub,
+          decodedToken.iss,
+          req,
+        );
+
+        return { validOrigin, decodedToken };
+      })
+      .catch(() => ({ validOrigin: false, decodedToken: null }));
+
+    if (result.validOrigin && result.decodedToken) {
+      done(null, result.decodedToken);
+      return;
+    }
+
+    done(new UnauthorizedException());
+  }
+}

--- a/libs/koala-nest/src/host/security/strategies/jwt.strategy.ts
+++ b/libs/koala-nest/src/host/security/strategies/jwt.strategy.ts
@@ -41,7 +41,16 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     return payload.exp - payload.iat > this.accessTokenTtlSeconds;
   }
 
-  validate(req: Request, payload: { sub: string; exp?: number; iat?: number }) {
+  validate(
+    req: Request,
+    payload: { sub: string; typ?: string; exp?: number; iat?: number },
+  ) {
+    if (payload.typ === AuthHttp.API_KEY_TOKEN_TYPE) {
+      throw new UnauthorizedException(
+        'Token de API Key não pode ser usado como Bearer JWT',
+      );
+    }
+
     const isRefreshRoute = isAuthRefreshRoute(req.url);
     const parsed = jwtPayloadSchema.parse(payload);
 

--- a/libs/koala-nest/src/infra/auth/api-key-authorization.service.ts
+++ b/libs/koala-nest/src/infra/auth/api-key-authorization.service.ts
@@ -1,0 +1,74 @@
+import { EnvConfig } from '@/core/utils/env.config';
+import { InternalSubnetValidator } from '@/core/utils/internal-subnet-validator';
+import {
+  matchApiKeyDomainOrigin,
+  resolveClientIp,
+} from '@/core/utils/match-api-key-domain-origin';
+import { ApiKeyType } from '@/domain/entities/api-key/enums/api-key-type.enum';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+@Injectable()
+export class ApiKeyAuthorizationService {
+  constructor(private readonly apiKeyRepository: IApiKeyRepository) {}
+
+  private async validateDomainOrigin(
+    origins: string[],
+    req: Request,
+  ): Promise<boolean> {
+    const clientIp = resolveClientIp(req);
+
+    if (!clientIp) {
+      return false;
+    }
+
+    // Marker: InternalSubnetValidator — removido pela CLI quando a flag não é escolhida
+    if (InternalSubnetValidator.validate(clientIp)) {
+      return true;
+    }
+
+    return matchApiKeyDomainOrigin(clientIp, origins);
+  }
+
+  async validateApiKey(
+    userId: string,
+    apiKeyId: string,
+    req: Request,
+  ): Promise<boolean> {
+    const apiKey = await this.apiKeyRepository.findById(apiKeyId);
+
+    if (!apiKey || apiKey.userId !== userId) {
+      return false;
+    }
+
+    const origins = apiKey.origin.split(',').map((origin) => origin.trim());
+
+    if (
+      (EnvConfig.isEnvTest || EnvConfig.isEnvDevelop) &&
+      origins.includes('*')
+    ) {
+      return true;
+    }
+
+    switch (apiKey.type) {
+      case ApiKeyType.domain:
+        return this.validateDomainOrigin(origins, req);
+      case ApiKeyType.host:
+        return origins.includes(req.hostname);
+      case ApiKeyType.uri: {
+        let uri = `${req.hostname}${req.path}`;
+
+        for (const param of Object.values(req.params)) {
+          if (typeof param === 'string' && param.length > 0) {
+            uri = uri.replace(`/${param}`, '');
+          }
+        }
+
+        return origins.includes(uri);
+      }
+      default:
+        return false;
+    }
+  }
+}

--- a/libs/koala-nest/src/infra/database/migrations/1781281330534-CreateApiKey.ts
+++ b/libs/koala-nest/src/infra/database/migrations/1781281330534-CreateApiKey.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateApiKey1781281330534 implements MigrationInterface {
+  name = 'CreateApiKey1781281330534';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "api_key" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "type" character varying NOT NULL,
+        "origin" character varying NOT NULL,
+        "key" character varying NOT NULL,
+        "user_id" uuid NOT NULL,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_api_key_id" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_api_key_user_id" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_api_key_user_id" ON "api_key" ("user_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_api_key_user_id"`);
+    await queryRunner.query(`DROP TABLE "api_key"`);
+  }
+}

--- a/libs/koala-nest/src/infra/repositories/api-key.repository.ts
+++ b/libs/koala-nest/src/infra/repositories/api-key.repository.ts
@@ -1,0 +1,45 @@
+import { ListResponse } from '@/core/types';
+import { ApiKey } from '@/domain/entities/api-key/api-key';
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
+import { DATA_SOURCE_PROVIDER_TOKEN } from '@/infra/database/data-source-factory';
+import { RepositoryBase } from '@/infra/repositories/repository.base';
+import { Inject, Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class ApiKeyRepository
+  extends RepositoryBase<ApiKey>
+  implements IApiKeyRepository
+{
+  constructor(@Inject(DATA_SOURCE_PROVIDER_TOKEN) dataSource: DataSource) {
+    super(dataSource, ApiKey);
+  }
+
+  findByIdForUser(id: string, userId: string): Promise<ApiKey | null> {
+    return this.findOneNormalized({ where: { id, userId } });
+  }
+
+  findById(id: string): Promise<ApiKey | null> {
+    return this.findOneNormalized({ where: { id } });
+  }
+
+  findManyByUserId(userId: string): Promise<ListResponse<ApiKey>> {
+    return this.repository
+      .findAndCount({
+        where: { userId },
+        order: { createdAt: 'DESC' },
+      })
+      .then(([items, count]) => ({
+        items: this.normalizeEntities(items),
+        count,
+      }));
+  }
+
+  save(apiKey: ApiKey): Promise<ApiKey> {
+    return this.repository.save(apiKey);
+  }
+
+  async delete(apiKey: ApiKey): Promise<void> {
+    await this.repository.remove(apiKey);
+  }
+}

--- a/libs/koala-nest/src/infra/repositories/repository.module.ts
+++ b/libs/koala-nest/src/infra/repositories/repository.module.ts
@@ -1,7 +1,9 @@
+import { IApiKeyRepository } from '@/domain/repositories/iapi-key.repository';
 import { IPersonRepository } from '@/domain/repositories/iperson.repository';
 import { IUserRepository } from '@/domain/repositories/iuser.repository';
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '@/infra/database/database.module';
+import { ApiKeyRepository } from '@/infra/repositories/api-key.repository';
 import { PersonRepository } from '@/infra/repositories/person.repository';
 import { UserRepository } from '@/infra/repositories/user.repository';
 
@@ -10,7 +12,13 @@ import { UserRepository } from '@/infra/repositories/user.repository';
   providers: [
     { provide: IPersonRepository, useClass: PersonRepository },
     { provide: IUserRepository, useClass: UserRepository },
+    { provide: IApiKeyRepository, useClass: ApiKeyRepository },
   ],
-  exports: [DatabaseModule, IPersonRepository, IUserRepository],
+  exports: [
+    DatabaseModule,
+    IPersonRepository,
+    IUserRepository,
+    IApiKeyRepository,
+  ],
 })
 export class RepositoryModule {}

--- a/libs/koala-nest/src/test/core/internal-subnet-validator.spec.ts
+++ b/libs/koala-nest/src/test/core/internal-subnet-validator.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test';
+import { InternalSubnetValidator } from '@/core/utils/internal-subnet-validator';
+
+describe('InternalSubnetValidator', () => {
+  it('aceita IPv4 privados', () => {
+    expect(InternalSubnetValidator.validate('10.0.0.5')).toBe(true);
+    expect(InternalSubnetValidator.validate('172.16.1.1')).toBe(true);
+    expect(InternalSubnetValidator.validate('192.168.0.10')).toBe(true);
+    expect(InternalSubnetValidator.validate('::ffff:10.1.2.3')).toBe(true);
+  });
+
+  it('rejeita IPv4 públicos', () => {
+    expect(InternalSubnetValidator.validate('203.0.113.10')).toBe(false);
+    expect(InternalSubnetValidator.validate('8.8.8.8')).toBe(false);
+  });
+});

--- a/libs/koala-nest/src/test/core/jwt.strategy.spec.ts
+++ b/libs/koala-nest/src/test/core/jwt.strategy.spec.ts
@@ -35,4 +35,18 @@ describe('JwtStrategy', () => {
     expect(user.sub).toBe('user-1');
     expect(user.profile).toBeUndefined();
   });
+
+  it('rejeita token tip=api-key mesmo em /auth/refresh', () => {
+    const request = { url: '/auth/refresh', get: () => undefined } as Request;
+    const now = Math.floor(Date.now() / 1000);
+
+    expect(() =>
+      strategy.validate(request, {
+        sub: 'user-1',
+        typ: 'api-key',
+        iat: now,
+        exp: now + 100 * 365 * 86400,
+      }),
+    ).toThrow(UnauthorizedException);
+  });
 });

--- a/libs/koala-nest/src/test/core/match-api-key-domain-origin.spec.ts
+++ b/libs/koala-nest/src/test/core/match-api-key-domain-origin.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { matchApiKeyDomainOrigin } from '@/core/utils/match-api-key-domain-origin';
+
+describe('matchApiKeyDomainOrigin', () => {
+  it('aceita IP cadastrado igual ao cliente', async () => {
+    expect(
+      await matchApiKeyDomainOrigin('203.0.113.10', ['203.0.113.10']),
+    ).toBe(true);
+  });
+
+  it('rejeita IP diferente', async () => {
+    expect(
+      await matchApiKeyDomainOrigin('203.0.113.10', ['198.51.100.1']),
+    ).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/nest",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "CLI para criar APIs NestJS com arquitetura DDD — copia módulos prontos para o seu repositório.",
   "license": "MIT",
   "type": "module",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { Glob } from "bun";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -99,6 +99,13 @@ function buildCli() {
     }
 
     writeFileSync(outputPath, output, "utf8");
+  }
+
+  const assetsSource = path.join(sourceDir, "assets");
+  const assetsOutput = path.join(outputDir, "assets");
+
+  if (existsSync(assetsSource)) {
+    cpSync(assetsSource, assetsOutput, { recursive: true });
   }
 
   console.log(`Build concluído: ${path.relative(rootDir, outputDir)}/`);


### PR DESCRIPTION
## Summary
- Adiciona estratégia aditiva `api-key` (CRUD `/api-key`, Passport strategy, validação de origem e subnet interna) junto com JWT/OAuth2.
- Gera automaticamente `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` no `.env` ao instalar auth e inclui assets de vibecoding (`add ai-context` / prompt no `new`).
- Documenta a 4.3.0 (patch notes, CHANGELOG, guias de instalação e autenticação) e alinha versão do site.

## Test plan
- [ ] CI verde (build, testes CLI e template)
- [ ] `kl-nest new` com `--auth jwt,api-key` gera CRUD de API Key e chaves JWT no `.env`
- [ ] `kl-nest add auth api-key` / `kl-nest add ai-context cursor` funcionam em projeto existente
- [ ] Autenticação via header `ApiKey` e Bearer JWT no `AuthGuard`
- [ ] Docs PT/EN de autenticação e patch notes refletem a 4.3.0


Made with [Cursor](https://cursor.com)