### PR TITLE
Corrige highlight de código na documentação

### DIFF
--- a/libs/doc/site/src/app/features/doc/doc-page.component.css
+++ b/libs/doc/site/src/app/features/doc/doc-page.component.css
@@ -1,1 +1,0 @@
-@import 'prism-themes/themes/prism-atom-dark.min.css';

--- a/libs/doc/site/src/app/features/doc/doc-page.component.ts
+++ b/libs/doc/site/src/app/features/doc/doc-page.component.ts
@@ -25,7 +25,6 @@ import { SeoService } from '../../core/services/seo.service';
 @Component({
   selector: 'app-doc-page',
   templateUrl: './doc-page.component.html',
-  styleUrl: './doc-page.component.css',
   imports: [MarkdownContentComponent, RouterLink, DocOnThisPageComponent, CopyFeedbackButtonComponent],
 })
 export class DocPageComponent {

--- a/libs/doc/site/src/styles.css
+++ b/libs/doc/site/src/styles.css
@@ -4,6 +4,8 @@
 @import './theme/grid.css';
 @import './theme/table.css';
 
+@import 'prism-themes/themes/prism-atom-dark.min.css';
+
 /* Font Awesome: famílias usadas — não usar all.min.css */
 @import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 @import '@fortawesome/fontawesome-free/css/solid.min.css';


### PR DESCRIPTION
## Summary
- Restaura o tema Prism (`prism-atom-dark`) no CSS global do site de docs.
- Remove o stylesheet encapsulado do `DocPageComponent`, que impedia as cores nos tokens gerados dinamicamente pelo Prism.

## Test plan
- [ ] Abrir uma página de docs com bloco de código e confirmar cores em keywords, strings e comments
- [ ] Conferir que o build de docs inclui `.token.*` em `styles-*.css` sem `_ngcontent`


Made with [Cursor](https://cursor.com)